### PR TITLE
gpio: Print debug information about unmatched devices & add tracing instrumentation to start_provider

### DIFF
--- a/boardswarm/src/dfu.rs
+++ b/boardswarm/src/dfu.rs
@@ -7,6 +7,7 @@ use tokio::sync::{
     mpsc::{self, Receiver},
     oneshot,
 };
+use tracing::instrument;
 use tracing::{info, warn};
 
 use crate::{
@@ -14,6 +15,7 @@ use crate::{
 };
 pub const PROVIDER: &str = "dfu";
 
+#[instrument(skip(server))]
 pub async fn start_provider(name: String, server: Server) {
     let provider_properties = &[
         (registry::PROVIDER_NAME, name.as_str()),

--- a/boardswarm/src/gpio.rs
+++ b/boardswarm/src/gpio.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use futures::StreamExt;
 use serde::Deserialize;
 use tokio_gpiod::{Chip, Lines};
+use tracing::instrument;
 use tracing::{debug, warn};
 
 use crate::{
@@ -37,6 +38,7 @@ impl GpioParameters {
     }
 }
 
+#[instrument(skip(parameters, server))]
 pub async fn start_provider(name: String, parameters: serde_yaml::Value, server: Server) {
     let provider_properties = &[
         (registry::PROVIDER_NAME, name.as_str()),

--- a/boardswarm/src/pdudaemon.rs
+++ b/boardswarm/src/pdudaemon.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use pdudaemon_client::PduDaemon;
 use serde::Deserialize;
+use tracing::instrument;
 
 use crate::{
     registry::{self, Properties},
@@ -49,6 +50,7 @@ fn setup_actuator<D: Display>(
     server.register_actuator(properties, actuator);
 }
 
+#[instrument(skip(parameters, server))]
 pub fn start_provider(name: String, parameters: serde_yaml::Value, server: Server) {
     let parameters: PduDaemonParameters = serde_yaml::from_value(parameters).unwrap();
     let provider_properties = &[

--- a/boardswarm/src/rockusb.rs
+++ b/boardswarm/src/rockusb.rs
@@ -9,6 +9,7 @@ use rockusb::libusb::Transport;
 use rusb::GlobalContext;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
+use tracing::instrument;
 use tracing::{info, warn};
 
 use crate::{
@@ -16,6 +17,8 @@ use crate::{
 };
 
 pub const PROVIDER: &str = "rockusb";
+
+#[instrument(skip(server))]
 pub async fn start_provider(name: String, server: Server) {
     let provider_properties = &[
         (registry::PROVIDER_NAME, name.as_str()),

--- a/boardswarm/src/serial/mod.rs
+++ b/boardswarm/src/serial/mod.rs
@@ -8,6 +8,7 @@ use std::{
     sync::{Arc, Mutex},
     task::{Context, Poll},
 };
+use tracing::instrument;
 use tracing::warn;
 
 use anyhow::Result;
@@ -21,6 +22,7 @@ use tokio_serial::{SerialPortBuilderExt, SerialStream};
 
 pub const PROVIDER: &str = "serial";
 
+#[instrument(skip(server))]
 pub async fn start_provider(name: String, server: Server) {
     let provider_properties = &[
         (registry::PROVIDER_NAME, name.as_str()),


### PR DESCRIPTION
gpio: Print debug information about unmatched devices
    
It can be helpful to understand why a gpio device wasn't registered. Rework
the registration code to check if it matches against the required device
earlier, then print the device's name and properties if the matching
fails e.g:
    
    DEBUG boardswarm::gpio: Ignoring gpio device /sys/devices/platform/AMDI0030:00/gpiochip0 - Properties { properties: {"udev.DEVNAME": "/dev/gpiochip0", ... }