### PR TITLE
Warn when match configuration is empty

### DIFF
--- a/boardswarm/src/gpio.rs
+++ b/boardswarm/src/gpio.rs
@@ -38,13 +38,17 @@ impl GpioParameters {
     }
 }
 
-#[instrument(skip(parameters, server))]
+#[instrument(fields(name), skip_all, level = "error")]
 pub async fn start_provider(name: String, parameters: serde_yaml::Value, server: Server) {
     let provider_properties = &[
         (registry::PROVIDER_NAME, name.as_str()),
         (registry::PROVIDER, PROVIDER),
     ];
     let parameters: GpioParameters = serde_yaml::from_value(parameters).unwrap();
+    if parameters.match_.is_empty() {
+        warn!("matches is empty - will match any gpio device");
+    }
+
     let mut registration = None;
     let mut devices = crate::udev::DeviceStream::new("gpio").unwrap();
     while let Some(d) = devices.next().await {

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Streaming;
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
 
 mod boardswarm_provider;
 mod config;
@@ -239,19 +239,31 @@ trait DeviceConfigItem {
 }
 
 impl DeviceConfigItem for config::Console {
+    #[instrument(fields(name = self.name), skip_all, level="error")]
     fn matches(&self, properties: &Properties) -> bool {
+        if self.match_.is_empty() {
+            warn!("Console matches is empty - will match any console");
+        }
         properties.matches(&self.match_)
     }
 }
 
 impl DeviceConfigItem for config::Volume {
+    #[instrument(fields(name = self.name), skip_all, level="error")]
     fn matches(&self, properties: &Properties) -> bool {
+        if self.match_.is_empty() {
+            warn!("Volume matches is empty - will match any volume");
+        }
         properties.matches(&self.match_)
     }
 }
 
 impl DeviceConfigItem for config::ModeStep {
+    #[instrument(skip_all, level = "error")]
     fn matches(&self, properties: &Properties) -> bool {
+        if self.match_.is_empty() {
+            warn!("ModeStep matches is empty - will match any device");
+        }
         properties.matches(&self.match_)
     }
 }

--- a/boardswarm/src/registry.rs
+++ b/boardswarm/src/registry.rs
@@ -36,6 +36,10 @@ impl Properties {
         self.properties.get(prop).map(String::as_ref)
     }
 
+    /// Tests if matches is a subset of the properties
+    ///
+    /// If properties is from a remote instance (`boardswarm.instance` is set) that has to be
+    /// explicitly matched otherwise it's a pure subset match (e.g. an empty set matches)
     pub fn matches<K, V, I>(&self, matches: I) -> bool
     where
         K: AsRef<str>,

--- a/boardswarm/src/registry.rs
+++ b/boardswarm/src/registry.rs
@@ -264,6 +264,9 @@ mod test {
         t.insert(NAME.to_string(), "test".to_string());
         assert!(props.matches(&t));
 
+        let empty: HashMap<String, String> = HashMap::new();
+        assert!(props.matches(empty));
+
         assert!(props.matches([(NAME, "test")]));
         assert!(props.matches([("udev.BADGER", "5")]));
 


### PR DESCRIPTION
If the `match` configuration is empty, we are (by-design) quite greedy and match any subdevice. Warn the user about that situation.