### PR TITLE
Sort output of "properties" command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "http",
  "http-serde",
  "indicatif",
+ "itertools 0.12.1",
  "json",
  "mprocs-vt100",
  "nix 0.27.1",
@@ -1250,6 +1251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,7 +1887,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -1898,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -1985,7 +1995,7 @@ dependencies = [
  "cassowary",
  "crossterm",
  "indoc",
- "itertools",
+ "itertools 0.11.0",
  "lru",
  "paste",
  "strum 0.25.0",

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -23,6 +23,7 @@ tokio-util = { version = "0.7.4", features = ["compat"] }
 serde_json = "1.0.91"
 tracing = "0.1.37"
 indicatif = { version = "0.17.3", features = ["improved_unicode"] }
+itertools = "0.12.1"
 bmap-parser = "0.1.0"
 async-compression = { version = "0.4.5", features = ["futures-io", "gzip"] }
 rockfile = "0.1.0"

--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -20,6 +20,7 @@ use bytes::{Bytes, BytesMut};
 use clap::{arg, builder::PossibleValue, Args, Parser, Subcommand, ValueEnum};
 use futures::{pin_mut, FutureExt, Stream, StreamExt, TryStreamExt};
 use http::Uri;
+use itertools::Itertools;
 use rockfile::boot::{
     RkBootEntry, RkBootEntryBytes, RkBootHeader, RkBootHeaderBytes, RkBootHeaderEntry,
 };
@@ -715,8 +716,8 @@ async fn main() -> anyhow::Result<()> {
                 }
                 ActuatorCommand::Properties => {
                     let properties = boardswarm.properties(ItemType::Actuator, actuator).await?;
-                    for (k, v) in properties {
-                        println!(r#""{}" => "{}""#, k, v);
+                    for key in properties.keys().sorted_unstable() {
+                        println!(r#""{}" => "{}""#, key, properties[key]);
                     }
                 }
             }
@@ -744,8 +745,8 @@ async fn main() -> anyhow::Result<()> {
                 }
                 ConsoleCommand::Properties => {
                     let properties = boardswarm.properties(ItemType::Console, console).await?;
-                    for (k, v) in properties {
-                        println!(r#""{}" => "{}""#, k, v);
+                    for key in properties.keys().sorted_unstable() {
+                        println!(r#""{}" => "{}""#, key, properties[key]);
                     }
                 }
             }
@@ -782,8 +783,8 @@ async fn main() -> anyhow::Result<()> {
                 }
                 VolumeCommand::Properties => {
                     let properties = boardswarm.properties(ItemType::Volume, volume).await?;
-                    for (k, v) in properties {
-                        println!(r#""{}" => "{}""#, k, v);
+                    for key in properties.keys().sorted_unstable() {
+                        println!(r#""{}" => "{}""#, key, properties[key]);
                     }
                 }
             }
@@ -939,8 +940,8 @@ async fn main() -> anyhow::Result<()> {
                 }
                 DeviceCommand::Properties => {
                     let properties = boardswarm.properties(ItemType::Device, device.id()).await?;
-                    for (k, v) in properties {
-                        println!(r#""{}" => "{}""#, k, v);
+                    for key in properties.keys().sorted_unstable() {
+                        println!(r#""{}" => "{}""#, key, properties[key]);
                     }
                 }
             }


### PR DESCRIPTION
"properties" is a hash map so there's no guaranteed order while iterating over it. From cli user's perspective this is confusing, because properties of the same item will be listed in random order each time this command is run.

Sort the output, using itertools.