### PR TITLE
Better inform about authentication

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -543,7 +543,9 @@ async fn run_configure(
         let info = boardswarm.login_info().await?;
 
         // TODO allow user select the !first one
-        let login = info.first().unwrap();
+        let login = info
+            .first()
+            .context("No OIDC authentication to choose from")?;
         println!("Starting login with {}", login.description);
         match &login.method {
             boardswarm_client::client::AuthMethod::Oidc { url, client_id } => {


### PR DESCRIPTION
Example session:

```
$ target/debug/boardswarm-cli -i my-boardswarm configure \
	--new --uri http://localhost:6683
thread 'main' panicked at boardswarm-cli/src/main.rs:538:34:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

is a result of not providing a JWT token, in which case OIDC is silently attempted.

This pull request does 2 things:

1) informs the user about which authentication method is being chosen, which makes the user aware that e.g. the actually
chosen method is OIDC even though the user might have thought otherwise

2) ensures that "unwrap()" is not called on a None variant, providing a meaningful message to the user instead of panic!()