### PR TITLE
boardswarm: Add example systemd service & udev rules

### DIFF
--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -111,6 +111,10 @@ For each item created by a provider the `boardswarm.provider.name` property
 is set to the configured name and the `boardswarm.provider` property is set to
 the provider used.
 
+As a starting point, the [example udev rules](share/99-boardswarm.rules) can be
+used to grant device permissions to boardswarm. It is recommended that these
+rules be used alongside the [example systemd service](share/boardswarm.service).
+
 ### Serial provider
 
 The serial provider creates consoles from local serial ports. No provider specific

--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -13,6 +13,9 @@ To run boardswarm a yaml configuration file needs to be passed as an argument.
 As a starting point the documented [example configuration](share/server.conf)
 can be used.
 
+To run as a systemd service, the [example systemd service](share/boardswarm.service)
+can be used.
+
 ## Authentication
 
 Boardswarm always validates authentication against [JWT] bearer tokens; The

--- a/boardswarm/share/99-boardswarm.rules
+++ b/boardswarm/share/99-boardswarm.rules
@@ -1,2 +1,6 @@
 # USB Serial devices
 ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", GROUP="boardswarm"
+
+# TI DFU devices
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6162", GROUP="boardswarm"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6165", GROUP="boardswarm"

--- a/boardswarm/share/99-boardswarm.rules
+++ b/boardswarm/share/99-boardswarm.rules
@@ -1,0 +1,2 @@
+# USB Serial devices
+ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", GROUP="boardswarm"

--- a/boardswarm/share/boardswarm.service
+++ b/boardswarm/share/boardswarm.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Boardswarm server
+
+[Service]
+Environment="RUST_LOG=info"
+ExecStart=/usr/local/bin/boardswarm /etc/boardswarm/server.conf
+Type=simple
+DynamicUser=yes
+StateDirectory=boardswarm
+ProtectHome=true
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add an example systemd service file to the share directory.