### PR TITLE
Eliminate some unwraps

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -136,10 +136,13 @@ where
 fn input_stream() -> impl Stream<Item = Bytes> {
     let stdin = tokio::io::stdin();
 
-    let mut stdin_termios = nix::sys::termios::tcgetattr(&stdin).unwrap();
+    let mut stdin_termios = nix::sys::termios::tcgetattr(&stdin)
+        .context("tcgetattr failed")
+        .unwrap();
 
     nix::sys::termios::cfmakeraw(&mut stdin_termios);
     nix::sys::termios::tcsetattr(&stdin, nix::sys::termios::SetArg::TCSANOW, &stdin_termios)
+        .context("tcsetattr failed")
         .unwrap();
 
     futures::stream::unfold(stdin, |mut stdin| async move {

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -998,16 +998,22 @@ async fn main() -> anyhow::Result<()> {
             gpio::PROVIDER => {
                 local.spawn_local(gpio::start_provider(
                     p.name,
-                    p.parameters.unwrap(),
+                    p.parameters.context("Missing gpio provider parameters")?,
                     server.clone(),
                 ));
             }
-            pdudaemon::PROVIDER => {
-                pdudaemon::start_provider(p.name, p.parameters.unwrap(), server.clone())
-            }
-            boardswarm_provider::PROVIDER => {
-                boardswarm_provider::start_provider(p.name, p.parameters.unwrap(), server.clone())
-            }
+            pdudaemon::PROVIDER => pdudaemon::start_provider(
+                p.name,
+                p.parameters
+                    .context("Missing pdudaemon provider parameters")?,
+                server.clone(),
+            ),
+            boardswarm_provider::PROVIDER => boardswarm_provider::start_provider(
+                p.name,
+                p.parameters
+                    .context("Missing boardswarm provider parameters")?,
+                server.clone(),
+            ),
             t => warn!("Unknown provider: {t}"),
         }
     }


### PR DESCRIPTION
Two changes:
- be a bit more verbose instead of panicking if gpio/pdudaemon/boardswarm provider(s) don't have parameters specified
- add "context" to some tc[g|s]etattr() invocations - not sure if this is a good thing, so feel free to ignore this change