### PR TITLE
Strip whitespace from config token before posting

### DIFF
--- a/boardswarm-cli/README.md
+++ b/boardswarm-cli/README.md
@@ -8,16 +8,16 @@ all options.
 The `auth` subcommand can be used to configure remote instances. To setup
 an instance while authenticating against an OIDC server one can simply run:
 ```
-$ boardswarm-cli  --instance <instance name> auth init  -u <instance url>
+$ boardswarm-cli  --instance <instance name> configure --new -u <instance url>
 ```
 
 To authenticate with a static JWT token it can be passed on the command line as
 well:
 ```
-$ boardswarm-cli  --instance <instance name> auth init -u <instance url> --token-file <path to token file>
+$ boardswarm-cli  --instance <instance name> configure --new -u <instance url> --token-file <path to token file>
 ```
 
-For more information see `boardswarm-cli auth --help`
+For more information see `boardswarm-cli configure --help`
 
 ## Boardswarm UI
 

--- a/boardswarm-client/src/authenticator.rs
+++ b/boardswarm-client/src/authenticator.rs
@@ -86,7 +86,7 @@ where
             if let Some(token) = auth.token().await {
                 req.headers_mut().insert(
                     http::header::AUTHORIZATION.as_str(),
-                    format!("Bearer {}", token).parse().unwrap(),
+                    format!("Bearer {}", token.trim()).parse().unwrap(),
                 );
             }
             inner.call(req).await


### PR DESCRIPTION
When reading the token from a config file, we can end up with trailing whitespace, causing an InvalidHeaderValue when we try to add it to the headers. Make sure we trim whitespace before posting.

----

Also contains a small change to fix boardswarm-cli/README.md for UI changes.