### PR TITLE
Minimize images stored in ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}/${{ matrix.binary }}
+          images: ghcr.io/${{ github.repository }}/${{ matrix.binary }}${{ github.ref != 'refs/heads/main' && '-ci' }}
           tags: |
             "type=ref,event=branch"
             "type=ref,suffix=-{{sha}},event=branch"
@@ -113,7 +113,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.binary }}/Dockerfile


### PR DESCRIPTION
Only push images to ghrc on push events to the repository rather then on anything that's not a pull request. Also only push from the main branch to main packages, from other branches push to a package with a `-ci` suffix to they're clearly seperated