### PR TITLE
cli: Don't log to stdout when running the ui

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -781,9 +781,10 @@ async fn print_item(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
-
     let opt = Opts::parse();
+    if !matches!(opt.command, Command::Ui { .. }) {
+        tracing_subscriber::fmt::init();
+    }
 
     let config_path = opt.config.clone().unwrap_or_else(|| {
         let mut c = dirs::config_dir().expect("Config directory not found");


### PR DESCRIPTION
For most commands logging to stdout/stderr makes total sense; When doing Ui it does not, so don't initial the fmt subscriber in that case