### PR TITLE
Support dynamic targets

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -967,7 +967,12 @@ async fn main() -> anyhow::Result<()> {
             match command {
                 VolumeCommand::Info => {
                     let info = boardswarm.volume_info(volume).await?;
-                    println!("Volume targets:");
+                    if info.exhaustive {
+                        println!("Volume targets:");
+                    } else {
+                        println!("Volume targets (non-exhaustive):");
+                    }
+
                     for target in &info.target {
                         print!("* {}: ", target.name);
                         if let Some(size) = target.size {

--- a/boardswarm-client/src/device.rs
+++ b/boardswarm-client/src/device.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use boardswarm_protocol::VolumeInfoMsg;
+use boardswarm_protocol::{VolumeInfoMsg, VolumeTarget};
 use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
 use tokio::{select, sync::broadcast};
@@ -87,7 +87,7 @@ impl DeviceVolume {
         &mut self,
         target: &str,
         length: Option<u64>,
-    ) -> Result<VolumeIo, tonic::Status> {
+    ) -> Result<(VolumeTarget, VolumeIo), tonic::Status> {
         let id = self
             .get_id()
             .ok_or_else(|| tonic::Status::unavailable("Volume currently not available"))?;

--- a/boardswarm-protocol/proto/boardswarm.proto
+++ b/boardswarm-protocol/proto/boardswarm.proto
@@ -168,6 +168,10 @@ message VolumeIoTarget {
   optional uint64 length = 3;
 }
 
+message VolumeIoTargetReply {
+  VolumeTarget target = 1;
+}
+
 message VolumeIoRead {
   uint64 length = 1;
   uint64 offset = 2;
@@ -198,7 +202,6 @@ message VolumeIoShutdown {
 message VolumeIoShutdownReply {
 }
 
-
 message VolumeIoRequest {
   oneof TargetOrRequest {
      VolumeIoTarget target = 1;
@@ -209,13 +212,14 @@ message VolumeIoRequest {
   }
 }
 
-// One result per read request -> should furfill full read request unless eof is reached
+// Each IO request has a matching reply
 message VolumeIoReply {
   oneof Reply {
-        VolumeIoReadReply read = 1;
-        VolumeIoWriteReply write = 2;
-        VolumeIoFlushReply flush = 3;
-        VolumeIoShutdownReply shutdown = 4;
+        VolumeIoTargetReply target = 1;
+        VolumeIoReadReply read = 2;
+        VolumeIoWriteReply write = 3;
+        VolumeIoFlushReply flush = 4;
+        VolumeIoShutdownReply shutdown = 5;
   }
 }
 

--- a/boardswarm-protocol/proto/boardswarm.proto
+++ b/boardswarm-protocol/proto/boardswarm.proto
@@ -149,13 +149,16 @@ message VolumeTarget {
   bool seekable = 4;
   /// target size in bytes if known
   optional uint64 size = 5;
-  /// blocksize of the underlying media; For optimal performance read/write request should be done 
+  /// blocksize of the underlying media; For optimal performance read/write request should be done
   /// at that size
   optional uint32 blocksize = 6;
 }
 
 message VolumeInfoMsg {
    repeated VolumeTarget target = 1;
+   /// Whether the list of target is exhaustive. If false there may be more
+   /// valid names then listend
+   bool exhaustive = 2;
 }
 
 message VolumeRequest {

--- a/boardswarm/src/boardswarm_provider/volume.rs
+++ b/boardswarm/src/boardswarm_provider/volume.rs
@@ -8,24 +8,26 @@ pub struct BoardswarmVolume {
     id: u64,
     remote: Boardswarm,
     targets: Vec<VolumeTargetInfo>,
+    exhaustive: bool,
 }
 
 impl BoardswarmVolume {
     pub async fn new(id: u64, mut remote: Boardswarm) -> Result<Self, tonic::Status> {
-        let targets = remote.volume_info(id).await?.target;
+        let info = remote.volume_info(id).await?;
 
         Ok(Self {
             id,
             remote,
-            targets,
+            targets: info.target,
+            exhaustive: info.exhaustive,
         })
     }
 }
 
 #[async_trait::async_trait]
 impl Volume for BoardswarmVolume {
-    fn targets(&self) -> &[VolumeTargetInfo] {
-        &self.targets
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (&self.targets, self.exhaustive)
     }
 
     async fn open(

--- a/boardswarm/src/boardswarm_provider/volume.rs
+++ b/boardswarm/src/boardswarm_provider/volume.rs
@@ -32,18 +32,15 @@ impl Volume for BoardswarmVolume {
         &self,
         target: &str,
         length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError> {
-        if !self.targets.iter().any(|t| t.name == target) {
-            return Err(VolumeError::UnknownTargetRequested);
-        }
-        let io = self
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
+        let (info, io) = self
             .remote
             .clone()
             .volume_io(self.id, target, length)
             .await
             .map_err(|e| VolumeError::Internal(e.to_string()))?;
 
-        Ok(Box::new(BoardswarmVolumeTarget { io }))
+        Ok((info.clone(), Box::new(BoardswarmVolumeTarget { io })))
     }
 
     async fn commit(&self) -> Result<(), VolumeError> {

--- a/boardswarm/src/dfu.rs
+++ b/boardswarm/src/dfu.rs
@@ -106,13 +106,13 @@ impl Volume for Dfu {
         &self,
         target: &str,
         length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError> {
-        if self.targets.iter().any(|t| t.name == target) {
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
+        if let Some(volume_target) = self.targets.iter().find(|t| t.name == target) {
             let tx = self
                 .device
                 .start_download(target.to_owned(), length.unwrap_or_default() as u32)
                 .await;
-            Ok(Box::new(DfuTarget { tx }))
+            Ok((volume_target.clone(), Box::new(DfuTarget { tx })))
         } else {
             warn!("Unknown target requested");
             Err(VolumeError::UnknownTargetRequested)

--- a/boardswarm/src/dfu.rs
+++ b/boardswarm/src/dfu.rs
@@ -98,8 +98,8 @@ impl Dfu {
 
 #[async_trait::async_trait]
 impl Volume for Dfu {
-    fn targets(&self) -> &[VolumeTargetInfo] {
-        self.targets.as_slice()
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (self.targets.as_slice(), true)
     }
 
     async fn open(

--- a/boardswarm/src/fastboot.rs
+++ b/boardswarm/src/fastboot.rs
@@ -451,12 +451,18 @@ impl Volume for FastbootVolume {
         &self,
         target: &str,
         _length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError> {
-        Ok(Box::new(FastbootVolumeTarget::new(
-            self.device.clone(),
-            target.to_string(),
-            self.max_download,
-        )))
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
+        let Some(info) = self.targets.iter().find(|t| t.name == target) else {
+            return Err(VolumeError::UnknownTargetRequested);
+        };
+        Ok((
+            info.clone(),
+            Box::new(FastbootVolumeTarget::new(
+                self.device.clone(),
+                target.to_string(),
+                self.max_download,
+            )),
+        ))
     }
 
     async fn commit(&self) -> Result<(), VolumeError> {

--- a/boardswarm/src/fastboot.rs
+++ b/boardswarm/src/fastboot.rs
@@ -504,8 +504,8 @@ impl FastbootVolume {
 
 #[async_trait::async_trait]
 impl Volume for FastbootVolume {
-    fn targets(&self) -> &[VolumeTargetInfo] {
-        &self.targets
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (&self.targets, false)
     }
 
     async fn open(

--- a/boardswarm/src/fastboot.rs
+++ b/boardswarm/src/fastboot.rs
@@ -22,6 +22,7 @@ pub const PROVIDER: &str = "fastboot";
 struct FastbootParameters {
     #[serde(rename = "match")]
     match_: HashMap<String, String>,
+    #[serde(default)]
     targets: Vec<String>,
 }
 

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -3,7 +3,8 @@ use boardswarm_protocol::item_event::Event;
 use boardswarm_protocol::{
     console_input_request, volume_io_reply, volume_io_request, ConsoleConfigureRequest,
     ConsoleInputRequest, ConsoleOutputRequest, ItemEvent, ItemList, ItemPropertiesMsg,
-    ItemPropertiesRequest, ItemTypeRequest, LoginInfoList, Property, VolumeInfoMsg, VolumeRequest,
+    ItemPropertiesRequest, ItemTypeRequest, LoginInfoList, Property, VolumeInfoMsg,
+    VolumeIoTargetReply, VolumeRequest,
 };
 use bytes::Bytes;
 use clap::Parser;
@@ -108,6 +109,7 @@ type VolumeIoReplyStream =
     ReceiverStream<Result<boardswarm_protocol::VolumeIoReply, tonic::Status>>;
 
 enum VolumeIoReply {
+    Target(VolumeTargetInfo),
     Read(oneshot::Receiver<Result<Bytes, tonic::Status>>),
     Write(oneshot::Receiver<Result<u64, tonic::Status>>),
     Flush(oneshot::Receiver<Result<(), tonic::Status>>),
@@ -127,6 +129,11 @@ impl VolumeIoReplies {
         tokio::spawn(async move {
             while let Some(completion) = completion_rx.recv().await {
                 let reply = match completion {
+                    VolumeIoReply::Target(t) => Ok(boardswarm_protocol::VolumeIoReply {
+                        reply: Some(volume_io_reply::Reply::Target(VolumeIoTargetReply {
+                            target: Some(t),
+                        })),
+                    }),
                     VolumeIoReply::Read(r) => {
                         let Ok(r) = r.await else { break };
                         r.map(|data| boardswarm_protocol::VolumeIoReply {
@@ -169,6 +176,10 @@ impl VolumeIoReplies {
         (Self { completion_tx }, ReceiverStream::new(reply_rx))
     }
 
+    fn enqueue_target_reply(&mut self, info: VolumeTargetInfo) {
+        let _ = self.completion_tx.send(VolumeIoReply::Target(info));
+    }
+
     fn enqueue_write_reply(&mut self, rx: oneshot::Receiver<Result<u64, tonic::Status>>) {
         let _ = self.completion_tx.send(VolumeIoReply::Write(rx));
     }
@@ -198,7 +209,7 @@ pub trait Volume: std::fmt::Debug + Send + Sync {
         &self,
         target: &str,
         length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError>;
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError>;
     async fn commit(&self) -> Result<(), VolumeError>;
 }
 
@@ -858,9 +869,10 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
                 .map(registry::Item::into_inner)
                 .ok_or_else(|| tonic::Status::not_found("No volume by that name"))?;
 
-            let mut target = volume.open(&target.target, target.length).await?;
-
             let (mut reply, reply_stream) = VolumeIoReplies::new();
+            let (info, mut target) = volume.open(&target.target, target.length).await?;
+            reply.enqueue_target_reply(info);
+
             tokio::spawn(async move {
                 while let Some(msg) = rx.message().await.transpose() {
                     let request = match msg {

--- a/boardswarm/src/mediatek_brom.rs
+++ b/boardswarm/src/mediatek_brom.rs
@@ -149,8 +149,8 @@ impl MediatekBromVolume {
 
 #[async_trait::async_trait]
 impl Volume for MediatekBromVolume {
-    fn targets(&self) -> &[VolumeTargetInfo] {
-        &self.targets
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (&self.targets, true)
     }
 
     async fn open(

--- a/boardswarm/src/mediatek_brom.rs
+++ b/boardswarm/src/mediatek_brom.rs
@@ -157,9 +157,12 @@ impl Volume for MediatekBromVolume {
         &self,
         target: &str,
         length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError> {
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
         if target == TARGET {
-            Ok(Box::new(BromVolumeTarget::new(self.device.clone(), length)))
+            Ok((
+                self.targets[0].clone(),
+                Box::new(BromVolumeTarget::new(self.device.clone(), length)),
+            ))
         } else {
             Err(VolumeError::UnknownTargetRequested)
         }

--- a/boardswarm/src/rockusb.rs
+++ b/boardswarm/src/rockusb.rs
@@ -184,8 +184,8 @@ impl Rockusb {
 
 #[async_trait::async_trait]
 impl Volume for Rockusb {
-    fn targets(&self) -> &[VolumeTargetInfo] {
-        &self.targets
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (&self.targets, true)
     }
 
     async fn open(

--- a/boardswarm/src/rockusb.rs
+++ b/boardswarm/src/rockusb.rs
@@ -192,24 +192,25 @@ impl Volume for Rockusb {
         &self,
         target: &str,
         _length: Option<u64>,
-    ) -> Result<Box<dyn VolumeTarget>, VolumeError> {
-        match &self.mode {
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
+        let Some(info) = self.targets.iter().find(|t| t.name == target) else {
+            return Err(VolumeError::UnknownTargetRequested);
+        };
+        let target: Box<dyn VolumeTarget> = match &self.mode {
             RockUsbMode::MaskRom => {
                 let area = match target {
                     "471" => 0x471,
                     "472" => 0x472,
                     _ => Err(VolumeError::UnknownTargetRequested)?,
                 };
-                Ok(Box::new(RockUsbMaskromTarget::new(
-                    area,
-                    self.commands.clone(),
-                )))
+                Box::new(RockUsbMaskromTarget::new(area, self.commands.clone()))
             }
             RockUsbMode::Loader((name, _size)) if name == target => {
-                Ok(Box::new(RockUsbTarget::new(self.commands.clone()).await?))
+                Box::new(RockUsbTarget::new(self.commands.clone()).await?)
             }
-            _ => Err(VolumeError::UnknownTargetRequested),
-        }
+            _ => return Err(VolumeError::UnknownTargetRequested)?,
+        };
+        Ok((info.clone(), target))
     }
 
     async fn commit(&self) -> Result<(), VolumeError> {


### PR DESCRIPTION
As not all volume protocols support discovering all valid targets, allow the user to specify targets names outside of the target list.