### PR TITLE
Add protocol/API/cli to erase volume targets

### DIFF
--- a/boardswarm-client/src/client.rs
+++ b/boardswarm-client/src/client.rs
@@ -10,8 +10,8 @@ use boardswarm_protocol::{
     boardswarm_client::BoardswarmClient, console_input_request, volume_io_reply, volume_io_request,
     ActuatorModeRequest, ConsoleConfigureRequest, ConsoleInputRequest, ConsoleOutputRequest,
     DeviceModeRequest, DeviceRequest, Item, ItemPropertiesRequest, ItemType, ItemTypeRequest,
-    VolumeInfoMsg, VolumeIoFlush, VolumeIoRead, VolumeIoReply, VolumeIoRequest, VolumeIoShutdown,
-    VolumeIoTarget, VolumeIoWrite, VolumeRequest, VolumeTarget,
+    VolumeEraseRequest, VolumeInfoMsg, VolumeIoFlush, VolumeIoRead, VolumeIoReply, VolumeIoRequest,
+    VolumeIoShutdown, VolumeIoTarget, VolumeIoWrite, VolumeRequest, VolumeTarget,
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, FutureExt, Stream, StreamExt};
@@ -346,6 +346,19 @@ impl Boardswarm {
     pub async fn volume_commit(&mut self, volume: u64) -> Result<(), tonic::Status> {
         let request = tonic::Request::new(VolumeRequest { volume });
         self.client.volume_commit(request).await?;
+        Ok(())
+    }
+
+    pub async fn volume_erase<S: Into<String>>(
+        &mut self,
+        volume: u64,
+        target: S,
+    ) -> Result<(), tonic::Status> {
+        let request = tonic::Request::new(VolumeEraseRequest {
+            volume,
+            target: target.into(),
+        });
+        self.client.volume_erase(request).await?;
         Ok(())
     }
 }

--- a/boardswarm-client/src/device.rs
+++ b/boardswarm-client/src/device.rs
@@ -117,6 +117,14 @@ impl DeviceVolume {
             Err(tonic::Status::unavailable("Volume currently not available"))
         }
     }
+
+    pub async fn erase<S: Into<String>>(&mut self, target: S) -> Result<(), tonic::Status> {
+        if let Some(id) = self.get_id() {
+            self.device.client.volume_erase(id, target).await
+        } else {
+            Err(tonic::Status::unavailable("Volume currently not available"))
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/boardswarm-protocol/proto/boardswarm.proto
+++ b/boardswarm-protocol/proto/boardswarm.proto
@@ -24,6 +24,8 @@ service Boardswarm {
 
   // Commit all data in an uploader specific manner; e.g. may trigger a USB reset for DFU devices
   rpc VolumeCommit(VolumeRequest) returns (google.protobuf.Empty);
+  // Erase all data of target
+  rpc VolumeErase(VolumeEraseRequest) returns (google.protobuf.Empty);
 
 }
 
@@ -163,6 +165,11 @@ message VolumeInfoMsg {
 
 message VolumeRequest {
   uint64 volume = 1;
+}
+
+message VolumeEraseRequest {
+  uint64 volume = 1;
+  string target = 2;
 }
 
 message VolumeIoTarget {


### PR DESCRIPTION
Some protocols allow erasing volumes (e.g. discard in case of flash). Add support for that in the protocol, cli and the fastboot volume provider