### PR TITLE
Increase UI terminal size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing",

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -36,3 +36,4 @@ url = { version = "2.5.3", features = ["serde"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 ratatui = "0.29.0"
 android-sparse-image = "0.1.2"
+thiserror = "2.0.6"

--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -712,6 +712,9 @@ enum Command {
         device: DeviceArg,
         #[command(flatten)]
         console: DeviceConsoleArgs,
+        #[clap(long, default_value_t = 5000)]
+        /// Number of lines to keep for scrollback
+        scrollback_lines: usize,
     },
 }
 
@@ -1335,12 +1338,16 @@ async fn main() -> anyhow::Result<()> {
             }
             Ok(())
         }
-        Command::Ui { device, console } => {
+        Command::Ui {
+            device,
+            console,
+            scrollback_lines,
+        } => {
             let device = device
                 .device(boardswarm)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Device not found"))?;
-            ui::run_ui(device, console.console).await
+            ui::run_ui(device, console.console, scrollback_lines).await
         }
     }
 }

--- a/boardswarm-cli/src/ui.rs
+++ b/boardswarm-cli/src/ui.rs
@@ -22,9 +22,10 @@ impl Terminal {
     async fn new(
         width: u16,
         height: u16,
+        scrollback_lines: usize,
         tui: TuiTerminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Self {
-        let parser = vt100::Parser::new(height, width, height as usize * 128);
+        let parser = vt100::Parser::new(height, width, scrollback_lines);
         let mut this = Self { parser, tui };
         this.update().await;
         this
@@ -144,6 +145,7 @@ where
 pub async fn run_ui(
     device: boardswarm_client::device::Device,
     console: Option<String>,
+    scrollback_lines: usize,
 ) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
 
@@ -165,7 +167,7 @@ pub async fn run_ui(
     )
     .unwrap();
 
-    let mut terminal = Terminal::new(80, 24, terminal).await;
+    let mut terminal = Terminal::new(80, 24, scrollback_lines, terminal).await;
     let mut console = match console {
         Some(console) => device.console_by_name(&console),
         None => device.console(),

--- a/boardswarm-cli/src/ui.rs
+++ b/boardswarm-cli/src/ui.rs
@@ -1,32 +1,98 @@
 use std::task::Poll;
+use std::{num::ParseIntError, str::FromStr};
 
 use bytes::Bytes;
 use futures::{pin_mut, ready, Stream, StreamExt};
 use ratatui::{
     backend::CrosstermBackend,
-    layout::Rect,
+    layout::{Rect, Size},
     widgets::{Block, Borders},
     Terminal as TuiTerminal,
 };
+use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::sync::ReusableBoxFuture;
+use tracing::warn;
 
 use crate::ui_term;
 
 struct Terminal {
     parser: vt100::Parser,
     tui: TuiTerminal<CrosstermBackend<std::io::Stdout>>,
+    size_setting: TerminalSizeSetting,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TerminalSizeSetting {
+    Fixed(Size),
+    Auto,
+}
+
+#[derive(Debug, PartialEq, Error)]
+pub enum TerminalSizeSettingError {
+    #[error("unable to parse terminal setting format")]
+    ParseError,
+    #[error("invalid size, width and height should greater than 0")]
+    InvalidSizeError,
+}
+
+impl From<ParseIntError> for TerminalSizeSettingError {
+    fn from(_: ParseIntError) -> Self {
+        TerminalSizeSettingError::ParseError
+    }
+}
+
+impl FromStr for TerminalSizeSetting {
+    type Err = TerminalSizeSettingError;
+
+    fn from_str(fmt: &str) -> Result<Self, Self::Err> {
+        if fmt == "auto" {
+            return Ok(TerminalSizeSetting::Auto);
+        }
+
+        // Try to parse terminal size format to get width and height
+        let (w, h) = fmt
+            .split_once('x')
+            .ok_or(TerminalSizeSettingError::ParseError)?;
+
+        // Try to convert the tuple values into u16
+        let width = w.parse::<u16>()?;
+        let height = h.parse::<u16>()?;
+
+        if width == 0 || height == 0 {
+            return Err(TerminalSizeSettingError::InvalidSizeError);
+        }
+
+        Ok(TerminalSizeSetting::Fixed(Size { width, height }))
+    }
 }
 
 impl Terminal {
     async fn new(
-        width: u16,
-        height: u16,
+        size_setting: TerminalSizeSetting,
         scrollback_lines: usize,
         tui: TuiTerminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Self {
-        let parser = vt100::Parser::new(height, width, scrollback_lines);
-        let mut this = Self { parser, tui };
+        let size = match size_setting {
+            TerminalSizeSetting::Fixed(s) => s,
+            TerminalSizeSetting::Auto => match tui.size() {
+                Ok(s) => s,
+                Err(_) => {
+                    warn!("Unable to retrieve terminal size, use default value ('80x24')");
+                    Size {
+                        width: 80,
+                        height: 24,
+                    }
+                }
+            },
+        };
+
+        let parser = vt100::Parser::new(size.height, size.width, scrollback_lines);
+        let mut this = Self {
+            parser,
+            tui,
+            size_setting,
+        };
         this.update().await;
         this
     }
@@ -52,12 +118,40 @@ impl Terminal {
     }
 
     async fn update(&mut self) {
+        let term_size = match self.size_setting {
+            TerminalSizeSetting::Fixed(s) => s,
+            TerminalSizeSetting::Auto => {
+                // Try to auto resize terminal and parser
+                if self.tui.autoresize().is_ok() {
+                    match self.tui.size() {
+                        Ok(s) => s,
+                        Err(_) => Size {
+                            width: 80,
+                            height: 24,
+                        },
+                    }
+                } else {
+                    // Fallback
+                    Size {
+                        width: 80,
+                        height: 24,
+                    }
+                }
+            }
+        };
+        self.parser.set_size(term_size.height, term_size.width);
+
         let screen = self.parser.screen();
         let term = ui_term::UiTerm::new(screen);
         self.tui
             .draw(|f| {
                 let area = f.area();
-                let term_area = Rect::new(0, 0, 80.min(area.width), 24.min(area.height));
+                let term_area = Rect::new(
+                    0,
+                    0,
+                    term_size.width.min(area.width),
+                    term_size.height.min(area.height),
+                );
                 f.render_widget(term, term_area);
                 if !screen.hide_cursor() && screen.scrollback() == 0 {
                     let cursor = screen.cursor_position();
@@ -145,6 +239,7 @@ where
 pub async fn run_ui(
     device: boardswarm_client::device::Device,
     console: Option<String>,
+    terminal_size_setting: TerminalSizeSetting,
     scrollback_lines: usize,
 ) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
@@ -167,7 +262,7 @@ pub async fn run_ui(
     )
     .unwrap();
 
-    let mut terminal = Terminal::new(80, 24, scrollback_lines, terminal).await;
+    let mut terminal = Terminal::new(terminal_size_setting, scrollback_lines, terminal).await;
     let mut console = match console {
         Some(console) => device.console_by_name(&console),
         None => device.console(),
@@ -243,5 +338,59 @@ pub async fn run_ui(
         //Ok(Ok(_)) => Ok(()),
         //Ok(Err(e)) => Err(e.into()),
         Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn terminal_size_setting() {
+        // Nominal
+
+        // auto string
+        let size = TerminalSizeSetting::from_str("auto");
+        assert_eq!(size, Ok(TerminalSizeSetting::Auto));
+
+        // Fixed string
+        let size = TerminalSizeSetting::from_str("166x58");
+        assert_eq!(
+            size,
+            Ok(TerminalSizeSetting::Fixed(Size {
+                width: 166,
+                height: 58
+            }))
+        );
+
+        // Errors
+
+        // Invalid string
+        let size = TerminalSizeSetting::from_str("random");
+        assert_eq!(size, Err(TerminalSizeSettingError::ParseError));
+
+        // Only a width
+        let size = TerminalSizeSetting::from_str("80");
+        assert_eq!(size, Err(TerminalSizeSettingError::ParseError));
+
+        // No height
+        let size = TerminalSizeSetting::from_str("80x");
+        assert_eq!(size, Err(TerminalSizeSettingError::ParseError));
+
+        // Invalid width format
+        let size = TerminalSizeSetting::from_str("80xA");
+        assert_eq!(size, Err(TerminalSizeSettingError::ParseError));
+
+        // Invalid height format
+        let size = TerminalSizeSetting::from_str("Ax24");
+        assert_eq!(size, Err(TerminalSizeSettingError::ParseError));
+
+        // Null width value
+        let size = TerminalSizeSetting::from_str("0x24");
+        assert_eq!(size, Err(TerminalSizeSettingError::InvalidSizeError));
+
+        // Null height value
+        let size = TerminalSizeSetting::from_str("80x0");
+        assert_eq!(size, Err(TerminalSizeSettingError::InvalidSizeError));
     }
 }


### PR DESCRIPTION
This merge requests aims to improve the terminal ergonomics in UI mode (see #87).

Previously, the console terminal size  was hardcoded to 80 characters x 24 lines. Now the UI size is auto detected and resized on the fly to fit the main terminal. 
A new option "--scrollback-lines" is also added to manually configure the scrollback buffer.
