### PR TITLE
Add mouse support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "boardswarm-protocol",
  "bytes",
  "clap",
+ "crossterm 0.28.1",
  "dirs 5.0.1",
  "futures",
  "http",
@@ -718,6 +719,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
+ "futures-core",
  "mio 1.0.3",
  "parking_lot",
  "rustix",

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -36,3 +36,4 @@ url = { version = "2.5.3", features = ["serde"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 ratatui = "0.29.0"
 android-sparse-image = "0.1.2"
+crossterm = { version="0.28.1", features = [ "event-stream"] }

--- a/boardswarm-cli/src/ui.rs
+++ b/boardswarm-cli/src/ui.rs
@@ -1,5 +1,6 @@
 use std::task::Poll;
 
+use anyhow::anyhow;
 use bytes::Bytes;
 use futures::{pin_mut, ready, Stream, StreamExt};
 use ratatui::{
@@ -162,7 +163,11 @@ async fn run_ui_internal(
 
     let mut terminal = Terminal::new(80, 24, tui_terminal).await;
 
-    let output = console.clone().stream_output().await?;
+    let output = console
+        .clone()
+        .stream_output()
+        .await
+        .map_err(|e| anyhow!("Console stream opening failed: '{}'", e.message()))?;
 
     let (input_tx, input_rx) = tokio::sync::mpsc::channel(16);
     let _writer = tokio::spawn(async move {

--- a/boardswarm-cli/src/ui.rs
+++ b/boardswarm-cli/src/ui.rs
@@ -1,16 +1,20 @@
-use std::task::Poll;
-
 use anyhow::anyhow;
 use bytes::Bytes;
-use futures::{pin_mut, ready, Stream, StreamExt};
+use futures::{pin_mut, FutureExt, StreamExt};
 use ratatui::{
     backend::CrosstermBackend,
+    crossterm::{
+        event::{
+            DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, KeyEvent,
+            KeyEventKind, KeyModifiers, MouseEventKind,
+        },
+        execute, ExecutableCommand,
+    },
     layout::Rect,
     widgets::{Block, Borders},
     DefaultTerminal, Terminal as TuiTerminal,
 };
-use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio_util::sync::ReusableBoxFuture;
+use std::io::stdout;
 
 use boardswarm_client::device::{Device, DeviceConsole};
 
@@ -70,79 +74,40 @@ impl Terminal {
     }
 }
 
-async fn process_input<R>(mut input: R) -> (Bytes, R)
-where
-    R: AsyncRead + Unpin,
-{
-    let mut buffer = [0; 4096];
-    let read = input.read(&mut buffer).await.unwrap();
-    (Bytes::copy_from_slice(&buffer[0..read]), input)
-}
-
 #[derive(Debug, Clone)]
 enum Input {
-    PowerOn,
-    PowerOff,
-    PowerReset,
     Up,
     Down,
     ScrollReset,
-    Bytes(Bytes),
     UIMessage(String),
 }
 
-struct InputStream<R> {
-    saw_escape: bool,
-    future: tokio_util::sync::ReusableBoxFuture<'static, (Bytes, R)>,
-}
-
-impl<R> InputStream<R>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
-    fn new(rx: R) -> Self {
-        let future = ReusableBoxFuture::new(process_input(rx));
-        Self {
-            saw_escape: false,
-            future,
+fn convert_keycode_to_term_code(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
+    let val = match code {
+        KeyCode::Esc => vec![0x1B_u8],
+        KeyCode::Enter => vec![b'\n'],
+        KeyCode::Tab => vec![b'\t'],
+        KeyCode::Backspace => vec![0x8_u8],
+        KeyCode::Insert => b"\x1B[2~".to_vec(),
+        KeyCode::Delete => b"\x1B[3~".to_vec(),
+        KeyCode::PageUp => b"\x1B[5~".to_vec(),
+        KeyCode::PageDown => b"\x1B[6~".to_vec(),
+        KeyCode::Home => b"\x1B[1~".to_vec(),
+        KeyCode::End => b"\x1B[4~".to_vec(),
+        KeyCode::Up => b"\x1B[A".to_vec(),    // CUU
+        KeyCode::Down => b"\x1B[B".to_vec(),  // CUD
+        KeyCode::Left => b"\x1B[D".to_vec(),  // CUB
+        KeyCode::Right => b"\x1B[C".to_vec(), // CUF
+        KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => vec![0x3_u8], // ^C ETX
+        KeyCode::Char('d') if modifiers == KeyModifiers::CONTROL => vec![0x4_u8], // ^D EOT
+        KeyCode::Char(c) => {
+            let mut b = [0; 4];
+            let result = c.encode_utf8(&mut b);
+            result.to_string().into_bytes()
         }
-    }
-
-    fn check_input(&mut self, input: Bytes) -> Option<Input> {
-        for i in &input {
-            match i {
-                0x1 => self.saw_escape = true, /* ^a */
-                b'q' if self.saw_escape => return None,
-                b'o' if self.saw_escape => return Some(Input::PowerOn),
-                b'f' if self.saw_escape => return Some(Input::PowerOff),
-                b'r' if self.saw_escape => return Some(Input::PowerReset),
-                b'k' if self.saw_escape => return Some(Input::Up),
-                b'j' if self.saw_escape => return Some(Input::Down),
-                // FIXME enter doesn't work
-                b'\n' if self.saw_escape => return Some(Input::ScrollReset),
-                b'0' if self.saw_escape => return Some(Input::ScrollReset),
-                _ => self.saw_escape = false,
-            }
-        }
-        Some(Input::Bytes(input))
-    }
-}
-
-impl<R> Stream for InputStream<R>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
-    type Item = Input;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let (data, rx) = ready!(self.future.poll(cx));
-        self.future.set(process_input(rx));
-
-        Poll::Ready(self.check_input(data))
-    }
+        _ => return None,
+    };
+    Some(val)
 }
 
 async fn run_ui_internal(
@@ -156,12 +121,6 @@ async fn run_ui_internal(
         f.render_widget(block, area);
     })?;
 
-    let stdin = tokio::io::stdin();
-    let mut stdin_termios = nix::sys::termios::tcgetattr(&stdin)?;
-
-    nix::sys::termios::cfmakeraw(&mut stdin_termios);
-    nix::sys::termios::tcsetattr(&stdin, nix::sys::termios::SetArg::TCSANOW, &stdin_termios)?;
-
     let mut terminal = Terminal::new(80, 24, tui_terminal).await;
 
     let output = console
@@ -171,7 +130,9 @@ async fn run_ui_internal(
         .map_err(|e| anyhow!("Console stream opening failed: '{}'", e.message()))?;
 
     let (input_tx, input_rx) = tokio::sync::mpsc::channel(16);
-    let _writer = tokio::spawn(async move {
+
+    // Handle device console stdout
+    let _output_writer = tokio::spawn(async move {
         pin_mut!(output);
         pin_mut!(input_rx);
         loop {
@@ -189,7 +150,6 @@ async fn run_ui_internal(
                         Input::Down => { terminal.scroll_down(); },
                         Input::ScrollReset => { terminal.scroll_reset(); },
                         Input::UIMessage(msg) => {terminal.process(msg.as_bytes())}
-                        _ => (),
                     }
                 }
             }
@@ -197,60 +157,110 @@ async fn run_ui_internal(
         }
     });
 
-    let reader = tokio::spawn(async move {
-        let input = InputStream::new(stdin);
-        console
-            .stream_input(input.filter_map(move |i| {
-                let device = device.clone();
-                let input_tx = input_tx.clone();
-                async move {
-                    match i {
-                        Input::PowerOn => {
-                            // Perform power on action
-                            if let Err(err) = device.change_mode("on").await {
-                                let err_msg: String =
-                                    format!("Change mode 'on' action failed: {}\r\n", err.code());
-                                input_tx.send(Input::UIMessage(err_msg)).await.unwrap();
+    // Handle keyboard and mouse events from local console interface
+    let event_listener = tokio::spawn(async move {
+        let mut event_stream = EventStream::new();
+        let mut saw_escape: bool = false;
+        loop {
+            let device = device.clone();
+            let input_tx = input_tx.clone();
+            let event = event_stream.next().fuse();
+
+            tokio::select! {
+                maybe_event = event => {
+                    match maybe_event {
+                        Some(Ok(event)) => match event {
+                            Event::Key(KeyEvent {
+                                code: key_code,
+                                modifiers,
+                                kind: KeyEventKind::Press,
+                                ..
+                            }) => {
+                                match key_code {
+                                    KeyCode::Char('a') if modifiers == KeyModifiers::CONTROL => {
+                                        saw_escape = true;
+                                    }
+
+                                    KeyCode::Char('q') if saw_escape => {
+                                        // Quit
+                                        break;
+                                    }
+                                    KeyCode::Char('k') if saw_escape => {
+                                        let _ = input_tx.send(Input::Up).await;
+                                    }
+                                    KeyCode::Char('j') if saw_escape => {
+                                        let _ = input_tx.send(Input::Down).await;
+                                    }
+                                    KeyCode::Char('o') if saw_escape => {
+                                        // Perform power on action
+                                        if let Err(err) = device.change_mode("on").await {
+                                            let err_msg: String =
+                                                format!("Change mode 'on' action failed: {}\r\n", err.code());
+                                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
+                                        }
+                                    }
+                                    KeyCode::Char('f') if saw_escape => {
+                                        // Perform power off action
+                                        if let Err(err) = device.change_mode("off").await {
+                                            let err_msg: String =
+                                                format!("Change mode 'off' action failed: {}\r\n", err.code());
+                                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
+                                        }
+                                    }
+                                    KeyCode::Char('r') if saw_escape => {
+                                        // Perform power off action
+                                        if let Err(err) = device.change_mode("off").await {
+                                            let err_msg: String =
+                                                format!("Change mode 'off' action failed: {}\r\n", err.code());
+                                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
+                                        }
+                                        // Perform power on action
+                                        if let Err(err) = device.change_mode("on").await {
+                                            let err_msg: String =
+                                                format!("Change mode 'on' action failed: {}\r\n", err.code());
+                                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
+                                        }
+                                    }
+
+                                    _ => {
+                                        // Reset escape code
+                                        saw_escape = false;
+
+                                        // Handle Enter key for output console
+                                        if key_code == KeyCode::Enter {
+                                            // Send scroll reset on output console
+                                            let _ = input_tx.send(Input::ScrollReset).await;
+                                        }
+
+                                        // Convert keycode to an equivalent value (ANSI or VT) for input console
+                                        if let Some(val) = convert_keycode_to_term_code(key_code, modifiers) {
+                                            let stream = futures::stream::once(async move { Bytes::from(val) } );
+                                            let _ = console.stream_input(stream).await;
+                                        }
+                                    },
+                                }
                             }
-                            None
-                        }
-                        Input::PowerOff => {
-                            // Perform power off action
-                            if let Err(err) = device.change_mode("off").await {
-                                let err_msg: String =
-                                    format!("Change mode 'off' action failed: {}\r\n", err.code());
-                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
-                            };
-                            None
-                        }
-                        Input::PowerReset => {
-                            // Perform power off action
-                            if let Err(err) = device.change_mode("off").await {
-                                let err_msg: String =
-                                    format!("Change mode 'off' action failed: {}\r\n", err.code());
-                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
-                            };
-                            // Perform power on action
-                            if let Err(err) = device.change_mode("on").await {
-                                let err_msg: String =
-                                    format!("Change mode 'on' action failed: {}\r\n", err.code());
-                                let _ = input_tx.send(Input::UIMessage(err_msg)).await;
-                            }
-                            None
-                        }
-                        Input::Up | Input::Down | Input::ScrollReset => {
-                            let _ = input_tx.send(i).await;
-                            None
-                        }
-                        Input::Bytes(data) => Some(data),
-                        Input::UIMessage(_) => None,
+                            Event::Mouse(mouse_event) => match mouse_event.kind {
+                                MouseEventKind::ScrollDown => {
+                                    let _ = input_tx.send(Input::Down).await;
+                                }
+
+                                MouseEventKind::ScrollUp => {
+                                    let _ = input_tx.send(Input::Up).await;
+                                }
+                                _ =>{},
+                            },
+                            _ => {},
+                        },
+                        None => {},
+                       Some(Err(_)) => panic!(),
                     }
                 }
-            }))
-            .await
+            };
+        }
     });
 
-    match reader.await {
+    match event_listener.await {
         Ok(_) => Ok(()),
         Err(e) => Err(e.into()),
     }
@@ -263,7 +273,11 @@ pub async fn run_ui(device: Device, console_name: Option<String>) -> anyhow::Res
     }
     .ok_or_else(|| anyhow::anyhow!("Console not available"))?;
 
-    let result = run_ui_internal(ratatui::init(), device, console).await;
+    execute!(std::io::stdout(), EnableMouseCapture)?;
+    let tui_terminal = ratatui::init();
+
+    let result = run_ui_internal(tui_terminal, device, console).await;
     ratatui::restore();
+    stdout().execute(DisableMouseCapture)?;
     result
 }


### PR DESCRIPTION
This merge request adds the mouse support in the UI mode to fix #88

In order to support it, the UI mode now explicitly relies  on Crossterm crate as terminal backend (ratatui already uses it as default).  Instead of managing the stdin input manually, the keyboard and mouse actions are now listened through Crossterm event handler, filtered, processed and then sent (if needed) to the device input or output consoles.  

Note: the MR relies on the commits from GH-151 (the first 3 ones) so to be merged after it.