### PR TITLE
Use ID_MODEL_ID instead of ID_MODEL for USB devices

### DIFF
--- a/boardswarm/src/dfu.rs
+++ b/boardswarm/src/dfu.rs
@@ -49,6 +49,7 @@ pub async fn start_provider(name: String, server: Server) {
                     continue;
                 };
 
+                // Match on ID_MODEL here; the device may advertise the optional idModel property.
                 let name = if let Some(model) = device.property("ID_MODEL") {
                     format!("{}/{} {}", busnum, devnum, model)
                 } else {

--- a/boardswarm/src/mediatek_brom.rs
+++ b/boardswarm/src/mediatek_brom.rs
@@ -39,7 +39,7 @@ impl SerialProvider for MediatekBromProvider {
         if device.property_u64("ID_VENDOR_ID", 16) != Some(0x0e8d) {
             return false;
         };
-        if device.property_u64("ID_MODEL", 16) != Some(0x0003) {
+        if device.property_u64("ID_MODEL_ID", 16) != Some(0x0003) {
             return false;
         };
 

--- a/boardswarm/src/rockusb.rs
+++ b/boardswarm/src/rockusb.rs
@@ -47,7 +47,7 @@ pub async fn start_provider(name: String, server: Server) {
                     continue;
                 };
 
-                let name = if let Some(model) = device.property("ID_MODEL") {
+                let name = if let Some(model) = device.property("ID_MODEL_ID") {
                     format!("{}/{} {}", busnum, devnum, model)
                 } else {
                     format!("{}/{}", devnum, devnum)


### PR DESCRIPTION
Some USB products may set ID_MODEL to its own custom string but if its not set then udev sets ID_MODEL to ID_MODEL_ID (e.g. the idProduct, the actual device's PID).

Both properties are set by udev's usb builtin - except in the cases where ID_MODEL is set by the USB device to a custom string. The _ID variants directly come from idVendor and idProduct (e.g. the actual VID and PID), while the bare ID_VENDOR and ID_MODEL variants first try to use manufacturer and product instead (e.g. the optional Manufacturer and Product strings provided by the USB device) when a fallback to the VID/PID.

Rework the code to use the _ID variants where device IDs are used. This causes no functional change.

Fixes: https://github.com/boardswarm/boardswarm/issues/160