### PR TITLE
Fix panics during mediatek brom volume setup

### DIFF
--- a/boardswarm/src/mediatek_brom.rs
+++ b/boardswarm/src/mediatek_brom.rs
@@ -76,8 +76,21 @@ async fn setup_volume(
             return;
         }
     };
-    let brom = port.execute(Brom::handshake(0x201000)).await.unwrap();
-    let hwcode = port.execute(brom.hwcode()).await.unwrap();
+    let brom = match port.execute(Brom::handshake(0x201000)).await {
+        Ok(brom) => brom,
+        Err(e) => {
+            warn!("Failed to perform brom handshake: {e}");
+            return;
+        }
+    };
+
+    let hwcode = match port.execute(brom.hwcode()).await {
+        Ok(hwcode) => hwcode,
+        Err(e) => {
+            warn!("Failed to retrieve brom hardware code: {e}");
+            return;
+        }
+    };
 
     info!("Hardware: {}", hwcode.code);
     properties.insert(


### PR DESCRIPTION
This merge request fixes a possible panic that I encountered while I was testing #161 on a Genio 1200 board:
```
     Running `target/debug/boardswarm /home/laeyraud/Dev/boardswarm_cfg/server.conf`
thread 'tokio-runtime-worker' panicked at boardswarm/src/mediatek_brom.rs:79:62:
called `Result::unwrap()` on an `Err` value: Brom(IncorrectHandshakeResponse)
```

I still don't know the conditions to make it trigger but better fix it anyway as it's an easy fix.