### PR TITLE
Add support for Linaro QCOMLT Debug Board

### DIFF
--- a/boardswarm/share/server.conf
+++ b/boardswarm/share/server.conf
@@ -53,6 +53,9 @@ providers:
   # over serial at the moment
   - name: mediatek-brom
     provider: mediatek-brom
+  # The QCOMLT Debug Board provides a number of actuators to allow DUT control
+  - name: qcomlt-debug-board
+    provider: qcomlt-debug-board
   # A fastboot provider for fastboot devices exposed over USB. As fastboot
   # partitions aren't necessarily discoverable this can be configured to match
   # certain devices and set a preconfigured set of targets

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -13,6 +13,7 @@ use futures::prelude::*;
 use futures::stream::BoxStream;
 use hifive_p550_mcu::HifiveP550MCUProvider;
 use mediatek_brom::MediatekBromProvider;
+use qcomlt_debug_board::QCOMLTDebugBoardProvider;
 use registry::{Properties, Registry, RegistryIndex};
 use std::fmt::Display;
 use std::net::{AddrParseError, SocketAddr};
@@ -38,6 +39,7 @@ mod gpio;
 mod hifive_p550_mcu;
 mod mediatek_brom;
 mod pdudaemon;
+mod qcomlt_debug_board;
 mod registry;
 mod rockusb;
 mod serial;
@@ -1163,6 +1165,14 @@ async fn main() -> anyhow::Result<()> {
                 )),
                 None => {
                     bail!("Mediatek brom provider requires the serial provider to be enabled")
+                }
+            },
+            qcomlt_debug_board::PROVIDER => match serial {
+                Some(ref s) => {
+                    s.add_provider(QCOMLTDebugBoardProvider::new(p.name, server.clone()))
+                }
+                None => {
+                    bail!("QCOMLT Debug Board provider requires the serial provider to be enabled")
                 }
             },
             rockusb::PROVIDER => {

--- a/boardswarm/src/qcomlt_debug_board.rs
+++ b/boardswarm/src/qcomlt_debug_board.rs
@@ -1,0 +1,244 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
+use tokio_serial::SerialPortBuilderExt;
+use tracing::{info, warn};
+
+use crate::{ActuatorError, ActuatorId, Server, registry, serial::SerialProvider, udev::Device};
+
+pub const PROVIDER: &str = "qcomlt-debug-board";
+
+pub struct QCOMLTDebugBoardProvider {
+    name: String,
+    server: Server,
+    registrations: HashMap<PathBuf, Vec<ActuatorId>>,
+}
+
+impl QCOMLTDebugBoardProvider {
+    pub fn new(name: String, server: Server) -> Self {
+        Self {
+            name,
+            server,
+            registrations: Default::default(),
+        }
+    }
+}
+
+impl SerialProvider for QCOMLTDebugBoardProvider {
+    fn handle(&mut self, device: &Device, _seqnum: u64) -> bool {
+        let provider_properties = &[
+            (registry::PROVIDER_NAME, self.name.as_str()),
+            (registry::PROVIDER, PROVIDER),
+        ];
+
+        /* QCOMLT Debug Board uses the default Atmel devkit VID/PIDs
+        but advertises a custom ID_VENDOR and ID_MODEL. */
+        if device.property_u64("ID_VENDOR_ID", 16) != Some(0x03eb) {
+            return false;
+        };
+        if device.property_u64("ID_MODEL_ID", 16) != Some(0x2404) {
+            return false;
+        };
+        if device.property("ID_VENDOR") != Some("Linaro") {
+            return false;
+        };
+        if device.property("ID_MODEL") != Some("DebugBoard") {
+            return false;
+        };
+
+        // We only care about the debug board's "management" serial port, e.g.
+        // the first serial port the device enumerates. This is used for functions
+        // such as turning the DUT power on, enabling USB VBUS, pressing buttons.
+        //
+        // The second serial port is used for the DUT console - that
+        // can be used by the regular serial provider (and matching by
+        // ID_USB_SERIAL_SHORT)
+        if device.property("ID_USB_INTERFACE_NUM") != Some("00") {
+            return false;
+        };
+
+        if let Some(node) = device.devnode()
+            && let Some(name) = node.file_name()
+        {
+            let Some(serial_number) = device.property("ID_USB_SERIAL_SHORT") else {
+                warn!(
+                    "Skipping QCOMLT Debug Board on {}: missing ID_USB_SERIAL_SHORT",
+                    node.display()
+                );
+                return false;
+            };
+
+            info!(
+                "Reserving console {} for QCOMLT Debug Board {}",
+                node.display(),
+                serial_number
+            );
+
+            let port = match tokio_serial::new(node.to_string_lossy(), 115200).open_native_async() {
+                Ok(port) => port,
+                Err(e) => {
+                    warn!("Failed to open QCOMLT Debug Board management serial port: {e}");
+                    return false;
+                }
+            };
+
+            let mut base_properties = device.properties(name.to_string_lossy());
+            base_properties.extend(provider_properties);
+            base_properties.insert("qcomlt_debug_board.serial", serial_number);
+
+            let (tx, exec) = tokio::sync::mpsc::channel(16);
+            tokio::spawn(process(port, exec));
+
+            let actuator_types = [
+                ("power", QCOMLTActuatorType::Power),
+                ("usb-vbus", QCOMLTActuatorType::UsbVbus),
+                ("power-button", QCOMLTActuatorType::PowerButton),
+                ("reset-button", QCOMLTActuatorType::ResetButton),
+            ];
+
+            let ids = actuator_types
+                .into_iter()
+                .map(|(actuator_name, actuator_type)| {
+                    let mut props = base_properties.clone();
+                    props.insert(
+                        registry::NAME,
+                        format!("{}.{}.{}", self.name, serial_number, actuator_name),
+                    );
+                    self.server.register_actuator(
+                        props,
+                        QCOMLTDebugBoardActuator {
+                            device: tx.clone(),
+                            actuator_type,
+                        },
+                    )
+                })
+                .collect();
+
+            self.registrations
+                .insert(device.syspath().to_path_buf(), ids);
+
+            return true;
+        }
+        false
+    }
+
+    fn remove(&mut self, device: &Device) {
+        if let Some(ids) = self.registrations.remove(device.syspath()) {
+            for id in ids {
+                self.server.unregister_actuator(id);
+            }
+        }
+    }
+}
+
+// TODO: Create a standalone rust library for the QCOMLTDebugBoard
+// similar to https://github.com/boardswarm/mediatek-brom rather than
+// sending raw bytes
+struct QCOMLTDebugBoardCommand(u8, tokio::sync::oneshot::Sender<Result<(), std::io::Error>>);
+
+async fn process(
+    mut port: tokio_serial::SerialStream,
+    mut exec: tokio::sync::mpsc::Receiver<QCOMLTDebugBoardCommand>,
+) {
+    while let Some(QCOMLTDebugBoardCommand(byte, sender)) = exec.recv().await {
+        let r = port.write_all(&[byte]).await;
+        let _ = sender.send(r);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum QCOMLTActuatorType {
+    Power,
+    UsbVbus,
+    PowerButton,
+    ResetButton,
+}
+
+#[derive(Debug)]
+struct QCOMLTDebugBoardActuator {
+    device: tokio::sync::mpsc::Sender<QCOMLTDebugBoardCommand>,
+    actuator_type: QCOMLTActuatorType,
+}
+
+#[async_trait::async_trait]
+impl crate::Actuator for QCOMLTDebugBoardActuator {
+    async fn set_mode(
+        &self,
+        parameters: Box<dyn erased_serde::Deserializer<'static> + Send>,
+    ) -> Result<(), ActuatorError> {
+        #[derive(Deserialize)]
+        struct ModeParameters {
+            mode: String,
+        }
+        let parameters = ModeParameters::deserialize(parameters).unwrap();
+        let byte = match self.actuator_type {
+            QCOMLTActuatorType::Power => match parameters.mode.as_str() {
+                "on" => b'P',
+                "off" => b'p',
+                _ => {
+                    warn!(
+                        "Unsupported mode '{}' for actuator {:?}",
+                        parameters.mode, self.actuator_type
+                    );
+                    return Err(ActuatorError());
+                }
+            },
+            QCOMLTActuatorType::UsbVbus => match parameters.mode.as_str() {
+                "on" => b'U',
+                "off" => b'u',
+                _ => {
+                    warn!(
+                        "Unsupported mode '{}' for actuator {:?}",
+                        parameters.mode, self.actuator_type
+                    );
+                    return Err(ActuatorError());
+                }
+            },
+            QCOMLTActuatorType::PowerButton => match parameters.mode.as_str() {
+                "on" => b'B',
+                "off" => b'b',
+                _ => {
+                    warn!(
+                        "Unsupported mode '{}' for actuator {:?}",
+                        parameters.mode, self.actuator_type
+                    );
+                    return Err(ActuatorError());
+                }
+            },
+            QCOMLTActuatorType::ResetButton => match parameters.mode.as_str() {
+                "on" => b'R',
+                "off" => b'r',
+                _ => {
+                    warn!(
+                        "Unsupported mode '{}' for actuator {:?}",
+                        parameters.mode, self.actuator_type
+                    );
+                    return Err(ActuatorError());
+                }
+            },
+        };
+        info!(
+            "Sending {:?} {} command",
+            self.actuator_type, parameters.mode
+        );
+        let (tx, rx) = oneshot::channel();
+        self.device
+            .send(QCOMLTDebugBoardCommand(byte, tx))
+            .await
+            .map_err(|e| {
+                warn!("Failed to send command to debug board: {e}");
+                ActuatorError()
+            })?;
+        rx.await
+            .map_err(|e| {
+                warn!("Debug board command response channel closed: {e}");
+                ActuatorError()
+            })?
+            .map_err(|e| {
+                warn!("Failed to write command to debug board: {e}");
+                ActuatorError()
+            })
+    }
+}


### PR DESCRIPTION
The Linaro Debug Board[0], also known as the QCOMLT Debug Board (where QCOMLT expands to Qualcomm Landing Team) is a small, open-source debug board which was designed to plug directly into various Qualcomm development kits and provide functionality allowing developers to debug the DUTs in a generic/remote-first way (e.g. provide ability to switch DUT power, measure DUT power, switch USB connection on/off to prevent back-feeding power and to put the DUT into various states by simulating button presses).

The debug board is currently used with cdba[1] as a way to provide remote access to many boards to developers. cdba is also used as a layer under GitLab CI to allow testing of Linux kernel and images under CI for some projects.

Unfortunately cbda doesn't scale too well and uses ssh as its communication backend (which amongst other problems lacks a granulated external authentication) so we would like to, over the long term, switch to a new tool for remote access. Boardswarm is a good candidate.

---

The Linaro QCOMLT Debug Board has an Atmel MCU with firmware which presents itself as two USB-CDC serial ports. Each device has a unique SerialNumber but uses generic Atmel product and vendor IDs.

The board enumerates in Linux as:

    usb 1-2: new full-speed USB device number 106 using xhci_hcd
    usb 1-2: New USB device found, idVendor=03eb, idProduct=2404, bcdDevice= 1.00
    usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
    usb 1-2: Product: DebugBoard
    usb 1-2: Manufacturer: Linaro
    usb 1-2: SerialNumber: 75eaaac075a445150202022343a460ff
    cdc_acm 1-2:1.0: ttyACM0: USB ACM device
    cdc_acm 1-2:1.2: ttyACM1: USB ACM device

The first enumerated serial port is used for controlling the Debug Board (e.g. controlling DUT power), while the second serial port is connected to the DUT as UART.

The support for the DUT UART port is handled by the existing serial provider, while support for the various functions exposed by the Debug Board's internal UART are exposed in boardswarm as Actuators.

There is also a separate function which allows getting the voltage/current drawn by the DUT; this hasn't yet been hooked up as there is no way (yet) in boardswarm to register measurement device(s), but have left TODOs in the code around this. Also, see [3].

[0]: Linaro Debug Board: https://git.codelinaro.org/linaro/qcomlt/debugboard
[1]: cdba: http://github.com/linux-msm/cdba
[3]: https://github.com/boardswarm/boardswarm/issues/164


Please note this is VERY early prototype, which does work, created for additional feedback.