### PR TITLE
boardswarm-cli: Add context to JSON deserialisation

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -1039,7 +1039,9 @@ async fn main() -> anyhow::Result<()> {
             let actuator = item_lookup(actuator, ItemType::Actuator, boardswarm.clone()).await?;
             match command {
                 ActuatorCommand::ChangeMode(c) => {
-                    let p = serde_json::from_str(&c.mode)?;
+                    let p = serde_json::from_str(&c.mode)
+                        .context("Failed to parse actuator mode as JSON")?;
+
                     boardswarm.actuator_change_mode(actuator, p).await?;
                 }
                 ActuatorCommand::Properties => {
@@ -1056,7 +1058,8 @@ async fn main() -> anyhow::Result<()> {
             let console = item_lookup(console, ItemType::Console, boardswarm.clone()).await?;
             match command {
                 ConsoleCommand::Configure(c) => {
-                    let p = serde_json::from_str(&c.configuration)?;
+                    let p = serde_json::from_str(&c.configuration)
+                        .context("Failed to parse console configuration as JSON")?;
                     boardswarm.console_configure(console, p).await?;
                 }
                 ConsoleCommand::Tail => {


### PR DESCRIPTION
When passing non-JSON to `boardswarm-cli actuator change-mode`, boardswarm-cli shows a slightly obscure error message which doesn't explain that the error is caused by JSON decode:

```
Error: expected value at line 1 column 1
```

Add context to the error message so that the error is a little more helpful the cause:

```
Error: Failed to parse actuator command as JSON

Caused by:
    expected value at line 1 column 1
```

Also apply the same fix to the console command deserialisation.

Fixes: https://github.com/boardswarm/boardswarm/issues/165