### PR TITLE
Build Docker containers for arm64 architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,15 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      DOCKER_TARGET_PLATFORMS: linux/amd64,linux/arm64
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.DOCKER_TARGET_PLATFORMS }}
       - uses: actions/checkout@v4
       - name: Extract Docker metadata
         id: meta
@@ -117,6 +123,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.binary }}/Dockerfile
+          platforms: ${{ env.DOCKER_TARGET_PLATFORMS }}
 
   allgreen:
     if: always()


### PR DESCRIPTION
In some cases wee are using arm64 devices to control DUTs. Build the containers in CI for arm64 platforms (as well as existing amd64 containers).