### PR TITLE
Tonic 0.13: 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,28 +141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,19 +174,16 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -217,26 +192,20 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
- "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -246,7 +215,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -361,7 +329,6 @@ dependencies = [
  "android-sparse-image",
  "anyhow",
  "async-trait",
- "axum",
  "axum-server",
  "boardswarm-client",
  "boardswarm-protocol",
@@ -372,10 +339,11 @@ dependencies = [
  "fastboot-protocol",
  "futures",
  "humantime-serde",
- "jwt-authorizer",
+ "jsonwebtoken",
  "mediatek-brom",
  "nusb",
  "pdudaemon-client",
+ "reqwest",
  "rockusb",
  "serde",
  "serde_yaml",
@@ -387,6 +355,7 @@ dependencies = [
  "tokio-udev",
  "tokio-util",
  "tonic",
+ "tower-oauth2-resource-server",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -412,7 +381,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "mprocs-vt100",
- "nix 0.29.0",
+ "nix 0.30.1",
  "ratatui 0.29.0",
  "rockfile",
  "serde",
@@ -444,7 +413,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tonic",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -791,6 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1169,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1201,30 +1171,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -1560,6 +1506,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1570,6 +1517,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
+ "serde",
 ]
 
 [[package]]
@@ -1687,34 +1635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt-authorizer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d72c47f96cdd849689e1a417a2b7206399b238dd8e2b1dfcea16f27185d00e"
-dependencies = [
- "axum",
- "chrono",
- "futures-core",
- "futures-util",
- "headers",
- "http",
- "http-body-util",
- "jsonwebtoken",
- "pin-project",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
- "tower-http",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mediatek-brom"
@@ -1928,6 +1848,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall_double"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "mprocs-vt100"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +1904,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2650,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2757,7 +2701,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3021,6 +2965,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,17 +3023,6 @@ dependencies = [
  "scopeguard",
  "unescaper",
  "winapi",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -3604,11 +3567,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -3624,12 +3586,11 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3637,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3651,54 +3612,18 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.9.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.9.0",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3709,6 +3634,29 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-oauth2-resource-server"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d66811f14f7a9308625390465dfa3897e715219342cce51c6198ffe11bd888f"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures-util",
+ "http",
+ "jsonwebtoken",
+ "log",
+ "mockall_double",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "tower",
+ "url",
+]
 
 [[package]]
 name = "tower-service"
@@ -3722,7 +3670,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -14,24 +14,24 @@ bytes = "1.10.1"
 clap = { version = "4.5", features = ["derive"] }
 futures = "0.3.31"
 mprocs-vt100 = "0.7.0"
-nix = { version = "0.29.0", features = ["term"] }
+nix = { version = "0.30.1", features = ["term"] }
 boardswarm-protocol = { version = "0.0.1", path = "../boardswarm-protocol" }
 boardswarm-client = { version = "0.0.1", path = "../boardswarm-client" }
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
-serde_json = "1.0.91"
+serde_json = "1.0.140"
 tracing = "0.1.40"
 indicatif = { version = "0.17.3", features = ["improved_unicode", "tokio"] }
 itertools = "0.14.0"
 bmap-parser = "0.2.0"
 async-compression = { version = "0.4.5", features = ["futures-io", "gzip"] }
 rockfile = "0.1.0"
-http = "1.2"
-serde = "1.0.194"
+http = "1.3.1"
+serde = "1.0.219"
 http-serde = "2.1"
 serde_yaml = "0.9.25"
 dirs = "6.0.0"
-async-trait = "0.1.74"
+async-trait = "0.1.88"
 url = { version = "2.5.3", features = ["serde"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 ratatui = "0.29.0"

--- a/boardswarm-client/Cargo.toml
+++ b/boardswarm-client/Cargo.toml
@@ -13,16 +13,16 @@ anyhow = "1.0.68"
 bytes = "1.10.1"
 futures = "0.3.31"
 boardswarm-protocol = { version = "0.0.1", path = "../boardswarm-protocol" }
-tokio = { version = "1.43.1", features = ["full"] }
-tonic = { version = "0.12.3", features = ["tls", "tls-native-roots"] }
+tokio = { version = "1.44.2", features = ["full"] }
+tonic = { version = "0.13", features = ["tls-native-roots", "tls-ring"] }
 tracing = "0.1.40"
 thiserror = "2.0.6"
-tower = "0.5"
-http = "1.2.0"
-serde = "1.0.194"
+tower = "0.5.2"
+http = "1.3.1"
+serde = "1.0.219"
 http-serde = "2.1"
 serde_yaml = "0.9.25"
 oauth2 = { version = "5.0.0-rc.1", default-features = false, features = ["reqwest"] }
-reqwest = { version = "0.12.4", default-features = false, features = ["json", "rustls-tls-native-roots"] }
-async-trait = "0.1.74"
+reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+async-trait = "0.1.88"
 url = { version = "2.5.3", features = ["serde"] }

--- a/boardswarm-client/src/authenticator.rs
+++ b/boardswarm-client/src/authenticator.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, task::Poll};
 
 use futures::future::BoxFuture;
 use tokio::sync::Mutex;
-use tonic::body::BoxBody;
+use tonic::body::Body;
 use tower::{Layer, Service};
 
 use crate::oidc::OidcClient;
@@ -64,9 +64,9 @@ pub struct AuthenticatorService<S> {
     authenticator: Arc<Authenticator>,
 }
 
-impl<S> Service<http::Request<BoxBody>> for AuthenticatorService<S>
+impl<S> Service<http::Request<Body>> for AuthenticatorService<S>
 where
-    S: Clone + Service<http::Request<BoxBody>> + Clone + Send + 'static,
+    S: Clone + Service<http::Request<Body>> + Clone + Send + 'static,
     S::Future: Send,
 {
     type Response = S::Response;
@@ -77,7 +77,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: http::Request<BoxBody>) -> Self::Future {
+    fn call(&mut self, mut req: http::Request<Body>) -> Self::Future {
         let auth = self.authenticator.clone();
         let inner = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, inner);

--- a/boardswarm-protocol/Cargo.toml
+++ b/boardswarm-protocol/Cargo.toml
@@ -14,14 +14,14 @@ futures = "0.3.31"
 prost = "0.13"
 prost-derive = "0.13"
 prost-types = "0.13"
-serde = { version = "1.0.194", features = ["derive"] }
-tokio = { version = "1.43.1", features = ["full"] }
-tonic = "0.12.3"
+serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.44.2", features = ["full"] }
+tonic = "0.13"
 
 [build-dependencies]
 prost-build = "0.13.1"
 prost-wkt-build = "0.6"
-tonic-build = "0.12.3"
+tonic-build = "0.13"
 
 [dev-dependencies]
-serde_json = "1.0.91"
+serde_json = "1.0.140"

--- a/boardswarm/Cargo.toml
+++ b/boardswarm/Cargo.toml
@@ -10,21 +10,21 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.68"
-async-trait = "0.1.74"
+async-trait = "0.1.88"
 bytes = "1.10.1"
 clap = { version = "4.5", features = ["derive"] }
 futures = "0.3.31"
 humantime-serde = "1.1.1"
 pdudaemon-client = { version = "0.1.2", default-features=false }
 boardswarm-protocol = { version = "0.0.1", path = "../boardswarm-protocol" }
-serde = { version = "1.0.194", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9.25"
 thiserror = "2.0.6"
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-serial = "5.4.4"
 tokio-udev = "0.9"
 tokio-util = { version = "0.7.4", features = ["compat"]}
-tonic = "0.12.3"
+tonic = "0.13"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.5.3"
@@ -33,11 +33,12 @@ tokio-stream = { version = "0.1.16", features = ["sync"] }
 boardswarm-client = { version = "0.0.1", path = "../boardswarm-client" }
 tokio-gpiod = "0.3.0"
 rockusb = { version = "0.2.0", features = [ "nusb" ] }
-jwt-authorizer = { version = "0.15", default-features = false, features = [ "tonic", "rustls-tls-native-roots", "chrono" ] }
-axum = "0.7.4"
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 nusb = "0.1.11"
 dfu-nusb = "0.1.0"
 mediatek-brom = { version = "0.1.0", features = ["tokio"] }
 fastboot-protocol = "0.3"
 android-sparse-image = "0.1.2"
+jsonwebtoken = "9.3.1"
+tower-oauth2-resource-server = { version = "0.4.0", default-features = false }
+reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls-native-roots"] }


### PR DESCRIPTION
Test bump to tonic 0.13 and axum 0.8 - Draft (apart from messy commits) as jwt-authorizer needs an update to tonic 0.13 first.. ideally