### PR TITLE
cli: Add progress bar to write-bmap command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
+ "tokio",
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "web-time",

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.41.1", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 serde_json = "1.0.91"
 tracing = "0.1.40"
-indicatif = { version = "0.17.3", features = ["improved_unicode"] }
+indicatif = { version = "0.17.3", features = ["improved_unicode", "tokio"] }
 itertools = "0.14.0"
 bmap-parser = "0.2.0"
 async-compression = { version = "0.4.5", features = ["futures-io", "gzip"] }


### PR DESCRIPTION
Issue: https://github.com/boardswarm/boardswarm/issues/38
Follow up of: https://github.com/boardswarm/boardswarm/pull/172

As done for the write-aimg command, add a status bar to write-bmap showing the current progress on the number of mapped bytes writen.