### PR TITLE
Add a draft website for Boardswarm

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,27 @@
+name: website
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme
+      - name: Sphinx build
+        run: |
+          sphinx-build boardswarm-website _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/boardswarm-website/Makefile
+++ b/boardswarm-website/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/boardswarm-website/boards/genio700.rst
+++ b/boardswarm-website/boards/genio700.rst
@@ -1,0 +1,327 @@
+======================
+MediaTek Genio 700 EVK
+======================
+
+This is a quick guide covering options available for configuring the MediaTek
+Genio 700 EVK. The official guide to connecting the board to a host can be
+found here:
+
+https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/get-started/connect.html
+
+Setting up serial
+=================
+
+Ensure that Boardswarm has sufficient permissions to read and USB serial
+devices that are added to the system by adding the following udev rule to the
+host running the boardswarm server. (This can be achieve by adding the file
+``/etc/udev/rules.d/99-boardswarm.rules`` with the following contents::
+
+    # USB Serial devices
+    ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", GROUP="boardswarm"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    $ sudo udevadm control --reload && sudo udevadm trigger
+
+Run the following command to monitor new consoles added to the boardswarm
+server::
+
+   $ boardswarm-cli monitor consoles -v
+
+Connect a microUSB cable to ``UART0`` on the EVK and the other end to the
+boardswarm server. Boardswarm will detect the new addition of new USB serial
+device and print out the devices ID, name and a list of properties that can be
+used to identify the new serial console in the boardswarm server config file.
+As the EVK uses a legitimate FDTI chip to provide the USB serial, the serial
+device has a unique serial number. As a result the ``udev.ID_SERIAL`` entry is
+considered the best option, as this uniquely identifies the device, even if the
+device is moved to a different USB port (unlike using ``udev.ID_PATH`` which
+specifies the device plugged into a specific USB port).
+
+Create a node under ``devices`` for the board and add a console node, also
+specifying the baud rate, which is 921600bps::
+
+   devices:
+     - name: genio-700-1
+       consoles:
+         - name: main
+           parameters:
+             rate: 921600
+           match:
+             udev.ID_USB_SERIAL: "FTDI_FT232R_UB_UART_<serial>"
+
+Once done, we can kill the boardswarm monitor with ``ctrl-c``.
+
+
+Setting up power
+================
+
+Board is powered with 12V via ``DC IN`` barrel jack. In order for the device to
+boot when power is applied, either a USB cable needs to be powered and
+connected to the ``Micro USB D/L`` port, or the power GPIO needs to be toggled
+on and off (see GPIO setup below for more information).
+
+For now we will assume that a cable has plugged into the ``Micro USB D/L`` port
+and we can power the board on and off by just applying power. Ensure that your
+PDU provider or other power control solution is configured and you know which
+port it's connected to. Power switching is managed by setting "modes" for the
+relevant device in the ``devices`` section.  The modes can be arbitraily named,
+however the UI provides commands for enabling and disabling power and thus
+expects modes named ``on`` and ``off``. Add these to a ``modes`` section under
+the board node::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          - name: on
+            depends: off
+            sequence:
+              - match: &pdu-genio-700-1
+                  boardswarm.name: pdu.<pdu>.port-<index>
+                parameters:
+                  mode: on
+          - name: off
+            sequence:
+              - match: *pdu-genio-700-1
+                parameters:
+                  mode: off
+                stabilisation: 2s
+
+Restart boardswarm for the configuration changes to take effect. You should now
+be able to switch the board on and off with boardswarm from the command line::
+
+    $ boardswarm device genio-700-1 mode off
+    $ boardswarm device genio-700-1 mode on
+
+If the board already has something installed to boot and you have setup the
+serial as detailed above, you should also be able to
+:ref:`access the serial console <guides/basic-functionality:terminal style access to the board>`.
+
+
+Setting up GPIO
+===============
+
+The FTDI USB serial chip used to provide access to the console on the Genio 700
+EVK also provides a number of GPIO pins that the board uses to enable USB
+control of the buttons found on the board. The details of how these GPIO pins
+are used is
+`documented in the MediaTek guide <https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/hw/g700-evk.html#ftdi-board-control>`_.
+The GPIO lines are exposed in Linux along with any other supported GPIO
+controller. Ensure that Boardswarm has sufficient permissions by setting up
+udev rules for it, for example by adding these lines to the file created when
+setting up serial::
+
+    # Give boardswarm access to GPIO devices:
+    ACTION=="add", SUBSYSTEM=="gpio", NAME="gpiochip%n", OWNER="root", GROUP="gpio", MODE="0660", TAG+="uaccess"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    $ sudo udevadm control --reload && sudo udevadm trigger
+
+To enable them in Boardswarm we need to add a gpio node in the providers
+section of the config. The same match used for the console should be used in
+this section too::
+
+    providers:
+      - name: "genio-700-1 ftdi"
+        provider: gpio
+        parameters:
+          match: &genio-700-1-dongle
+            udev.ID_USB_SERIAL: "FTDI_FT232R_UB_UART_<serial>"
+          lines:
+            - line_number: 0
+              name: "genio-700-1-power"
+            - line_number: 1
+              name: "genio-700-1-reset"
+            - line_number: 2
+              name: "genio-700-1-download"
+
+Note that this section is also used to select the specific GPIO pins that will
+be controlled by Boardswarm and the names that can be used to identify them.
+
+These GPIO can then be used to perform operations, typically as sequences
+performed on mode changes. For example, if it is not desired to have a USB
+cable connected to the ``Micro USB D/L`` port of the EVK (however it should be
+noted this will be necessary for some of the following more complex operations
+which can be performed with the board), pressing of the power button can be
+simulated via the relevant pin as part of the ``on`` mode::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          - name: on
+            depends: off
+            sequence:
+              # Apply power
+              - match: &pdu-genio-700-1
+                  boardswarm.name: pdu.<pdu>.port-<index>
+                parameters:
+                  mode: on
+              # Toggle power button on and off
+              - match: &gpio-genio-700-1-power
+                  boardswarm.name: "genio-700-1-power"
+                parameters:
+                  value: true
+                stabilisation: 500ms
+              - match: *gpio-genio-700-1-power
+                parameters:
+                  value: false
+
+
+Setting up mediatek-brom
+========================
+
+With the GPIO enabled we can cause the board to boot into download mode. To use
+this mode we need a USB cable connecting the ``Micro USB D/L`` port to the
+boardswarm server.
+
+To enter download mode we add another mode to the device node, which can be
+called instead of the "on" mode to put the board into download mode::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          ...
+          - name: download
+            depends: off
+            sequence:
+              # Hold down "download" button
+              - match: &gpio-genio-700-1-download
+                  boardswarm.name: "genio-700-1-download"
+                parameters:
+                  value: true
+                stabilisation: 100ms
+              # Power on the board and stabilise
+              - match: *gpio-genio-700-1-power
+                parameters:
+                  mode: on
+                stabilisation: 2s
+              # Stop holding down the "download" button
+              - match: *gpio-genio-700-1-download
+                parameters:
+                  value: false
+
+Add a ``mediatek-brom`` node to the providers section to enable support for the
+MediaTek protocol used in this mode::
+
+    providers:
+      - name: mediatek-brom
+        provider: mediatek-brom
+
+Restart boardswarm to update the configuration.
+
+Ensure that Boardswarm has sufficient permissions to access the interface
+that's created in this mode by setting up a udev rule for it::
+
+    # MediaTek BROM
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="0003", MODE="0660", TAG+="uaccess"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    $ sudo udevadm control --reload && sudo udevadm trigger
+
+Use the monitor to watch for volumes and print out details when a volume is seen::
+
+   $ boardswarm-cli monitor volumes -v
+
+From another terminal, switch the board into download mode::
+
+   $ boardswarm-cli device genio-700-1 mode download
+
+The ``mediatek-brom`` will detect the new connection on the ``Micro USB D/L``
+port and print out it's properties. Use this to create a volume under the board
+node. The serial provided by this interface is not unique, so here we will need
+to add a match using the ``ID_PATH`` property::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          ...
+        volumes:
+          - name: genio-700-1-brom
+            match:
+              udev.ID_PATH: "<id_path>"
+
+Restart boardswarm to update the configuration.
+
+Setting up fastboot
+===================
+
+Genio devices can use the ``mediatek-brom`` mode to upload a
+`littlekernel <https://github.com/littlekernel>`_ based binary to bootstrap
+into a fastboot mode. To be able to use fastboot we need to enable and
+configure the boardswarm fastboot provider::
+
+    providers:
+      ...
+      - name: genio-fastboot
+        provider: fastboot
+        parameters:
+          match:
+            udev.ID_VENDOR_ID: 0e8d
+            udev.ID_MODEL_ID: 201c
+          targets:
+            - mmc0
+            - mmc0boot0
+            - mmc0boot1
+            - root
+
+Restart boardswarm to update the configuration.
+
+We also need to add some udev rules to allow the boardswarm server to have
+access to the required device files::
+
+    # MediaTek Fastboot
+    ACTION=="add", SUBSYSTEM=="usb", ENV{ID_USB_INTERFACES}==":ff4203:", GROUP="boardswarm"
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="201c", MODE="0660", TAG+="uaccess"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    $ sudo udevadm control --reload && sudo udevadm trigger
+
+With this and the ``mediatek-brom`` configured we can now use that to upload
+the littlekernel binary used to bootstrap into fastboot (this will typically be
+provided along side OS images to aid with flashing devices)::
+
+    $ boardswarm-cli device genio-700-1 mode off
+    $ boardswarm-cli device genio-700-1 mode download
+    $ boardswarm-cli device genio-700-1 write --commit genio-700-1-brom brom lk.bin
+
+The monitor launched above will show a ``mediatek-brom`` volume being created
+when powering on the board in download mode, which will be removed and replaced
+with a volume with the ``"boardswarm.provider" => "fastboot"`` property once
+bootstrapped into fastboot. As with ``mediatek-brom``, the serial number here
+is not unique, so we will create a volume node for the device using the
+``ID_PATH`` property listed for this volume::
+
+    volumes:
+      ...
+      - name: genio-700-1-fastboot
+        match:
+          udev.ID_PATH: "<id_path>"
+
+Restart boardswarm to update the configuration.
+
+
+Reflashing board
+================
+
+With Fastboot setup, we can reflash the board with the following commands::
+
+    $ boardswarm-cli device genio-700-1 write --commit genio-700-1-fastboot mmc0boot0 fip.img
+    $ boardswarm-cli device genio-700-1 write-aimg --commit genio-700-1-fastboot mmc0 <image>
+
+Reset the board to boot to the newly installed image. This can be achieved by
+power cycling the board or by toggling the reset GPIO on and off::
+
+    $ boardswarm-cli actuator genio-700-evk-reset change-mode '{"value": true}'
+    $ boardswarm-cli actuator genio-700-evk-reset change-mode '{"value": false}'
+

--- a/boardswarm-website/conf.py
+++ b/boardswarm-website/conf.py
@@ -1,0 +1,47 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Boardswarm'
+copyright = 'Boardswarm authors'
+author = 'Boardswarm authors'
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+#extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# Add the extension
+extensions = [
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
+]
+
+# Make sure the target is unique
+autosectionlabel_prefix_document = True
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+html_theme_options = {
+    'prev_next_buttons_location': None,
+}
+
+html_context = {
+  'display_github': True,
+  'github_user': 'boardswarm',
+  'github_repo': 'boardswarm',
+  'github_version': 'main/boardswarm-website/',
+}

--- a/boardswarm-website/guides/basic-functionality.rst
+++ b/boardswarm-website/guides/basic-functionality.rst
@@ -1,0 +1,64 @@
+===================
+Basic Functionality
+===================
+
+Listing available devices
+=========================
+
+The boards available on the boardswarm server can be listed with the following
+command::
+
+   $ boardswarm-cli list devices
+
+This command provides a list of the board IDs and names.
+
+
+Terminal style access to the board
+==================================
+
+The console UI is the main way to interact with development boards hosted on a
+Boardswarm server. This UI can be launched with the following command::
+
+   $ boardswarm-cli ui <device name or id>
+
+Where the device name or ID is one from the previous command.
+
+The UI has 2 modes, console and command. The console mode allows the user to
+interact with the serial console of the remote board. In the command mode the
+user can perform boardswarm specific operations. When launching the Boardswarm
+UI it is initially in the console mode. The command mode can be entered by
+sending ``<ctrl>-a`` (abbreviated below as ``^a``). This is typically followed by
+one of the below commands. The connection will stay in command mode until ``ESC``
+is sent.
+
+the follow commands are available:
+
+=== ====================================================================
+Key Command mode binding
+=== ====================================================================
+q   Quit the ui
+o   Change the device to mode "on"
+f   Change the device to mode "off"
+r   Reset the device's power (same as changing mode to "off" then "on")
+k   Scroll up
+j   Scroll down
+0   Reset scrolling state
+ESC Leave command mode
+=== ====================================================================
+
+
+Changing power state outside of the console UI
+==============================================
+
+The power state of a board can be changed from the commandline via the
+``device`` ``mode`` subcommand::
+
+    $ boardswarm-cli device <device name or id> mode <mode>
+
+It is typical for a devices config to provide ``on`` and ``off`` modes, but
+this is convention rather than required. The following command can be used to
+list basic information about a boards configuration, including the available
+modes (in JSON format)::
+
+    $ boardswarm-cli device <device name or id> info
+

--- a/boardswarm-website/guides/gpio-control.rst
+++ b/boardswarm-website/guides/gpio-control.rst
@@ -1,0 +1,29 @@
+============
+GPIO control
+============
+
+Controlling specific GPIOS directly
+===================================
+
+GPIOs can be hooked up to ancillary signals which can be used to put the board
+into alternative states, such as a download mode. In instances like this it
+would be best to define a mode to perform this operation, however GPIOs can
+also be used for ephemeral changes, such as toggling reset lines. In these
+instances it may be preferable to keep the board in it's current mode and
+toggle the line separately. GPIOs fall under the category of "actuators", the
+available actuators can be listed with the following command::
+
+    $ boardswarm-cli list actuators
+
+This list will include all the actuators available, which will include any
+switchable PSU ports, etc. Take care to ensure you are not switching an
+actuator assigned to another device.
+
+The ``actuators`` command provides the ``change-mode`` sub-command. This takes
+an "Actuator specific mode in json format". GPIOs expect a field named
+``value``, with a boolean value. So to enable a GPIO::
+
+    $ boardswarm-cli actuator <actuator name or id> change-mode '{"value": true}'
+
+
+

--- a/boardswarm-website/guides/python-scripting.rst
+++ b/boardswarm-website/guides/python-scripting.rst
@@ -1,0 +1,44 @@
+===========================================
+Automating tasks with Python and Boardswarm
+===========================================
+
+There are frequently times during development or when debugging an issue when
+having the ability to automate frequently performed tasks or create a quick
+script to loop testing a device that occasionaly fails can be really
+beneficial. If the devices are already being used in boardswarm, doing this can
+be trivial.
+
+Here's a quick example using `Python <https://www.python.org/>`_ and
+`pexpect <https://pexpect.readthedocs.io/en/stable/>`_, which powers up a
+board, waits for a login prompt, logs in and powers the machine back off. (Not
+particularly useful in this form, I know, but it does form the basis for a
+number of tasks)::
+
+    #!/usr/bin/python3
+    import os
+    import pexpect
+    import time
+    
+    device="<your devices name here>"
+    
+    # Ensure device is off
+    os.system(f'boardswarm-cli device {device} mode off')
+    
+    # Attach console
+    child = pexpect.spawn(f'boardswarm-cli device {device} connect')
+    
+    # Power up board
+    os.system(f'boardswarm-cli device {device} mode on')
+    
+    match = child.expect(["login:"], timeout=120)
+    
+    child.send("user\n")
+    child.expect(["Password:"])
+    
+    child.send("user\n")
+    time.sleep(4)
+    child.expect(['$'])
+    
+    child.send("sudo poweroff\n")
+    child.expect(["reboot: Power down"])
+

--- a/boardswarm-website/guides/setup-client.rst
+++ b/boardswarm-website/guides/setup-client.rst
@@ -1,0 +1,5 @@
+==============================
+Setting up a Boardswarm client
+==============================
+
+Installing and configuring a Boardswarm client is currently documented in the `boardswarm client documentation <https://github.com/boardswarm/boardswarm/blob/main/boardswarm-cli/README.md>`_.

--- a/boardswarm-website/guides/setup-server.rst
+++ b/boardswarm-website/guides/setup-server.rst
@@ -1,0 +1,5 @@
+==============================
+Setting up a Boardswarm server
+==============================
+
+Installing and configuring a Boardswarm server is currently documented in the `boardswarm server documentation <https://github.com/boardswarm/boardswarm/blob/main/boardswarm/README.md>`_.

--- a/boardswarm-website/index.rst
+++ b/boardswarm-website/index.rst
@@ -1,0 +1,46 @@
+
+==========
+Boardswarm
+==========
+
+Boardswarm provides a distributed service to interact with development boards.
+It is able to interact with the boards via their serial consoles, manage power,
+auxillary control lines and using a growing number of protocols, such as:
+
+- Device Firmware Upgrade (DFU)
+- Fastboot
+- MediaTek Boot ROM protocol
+- Rockchip USB protocol
+
+The connection between the boardswarm server and client application can be
+secured using multiple authentication mechanisms.
+
+
+Where can I get Boardswarm?
+===========================
+
+Boardswarm is a relatively new project and under active development. The latest releases, built by the projects CI build process can be found here:
+
+  https://github.com/boardswarm/boardswarm/releases/tag/latest
+
+Full source code can be found in our github repository:
+
+  https://github.com/boardswarm/boardswarm
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   guides/setup-server.rst
+   guides/setup-client.rst
+   guides/basic-functionality.rst
+   guides/gpio-control.rst
+   guides/python-scripting.rst
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Worked board examples
+
+   boards/genio700.rst
+

--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -177,6 +177,20 @@ provider:
         - mmc0boot1
 ```
 
+### MediaTek boot ROM provider (mediatek-brom)
+
+Support for MediaTek boot ROM protocol. mediatek-brom devices are automatically
+detected by scanning for USB serial devices with vendor ID `0x0e8d` and
+product ID `0x0003`. No provider specific parameters are expected and only one
+of this provider can exist.
+
+Example configuration:
+```
+provider:
+  - name: mediatek-brom
+    provider: mediatek-brom
+```
+
 ### Rock USB provider (rockusb)
 
 Support for rockchip USB protocol. rockusb devices are autodetected

--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -152,6 +152,31 @@ provider:
     provider: dfu
 ```
 
+### Fastboot provider (fastboot)
+
+Support for the fastboot communication protocol exposed over USB. As fastboot
+partitions aren't necessarily discoverable this can be configured to match
+certain devices and set a preconfigured set of targets, though autodetection
+will be attempted.
+
+Example configuration:
+```
+provider:
+  - name: fastboot
+    provider: fastboot
+    parameters:
+      match:
+        # Example with vendor and model IDs for MediaTek Genio devices
+        udev.ID_VENDOR_ID: 0e8d
+        udev.ID_MODEL_ID: 201c
+      # List of pre-defined targets; the provider will still try to detect
+      # other partitions by via the "all" variable
+      targets:
+        - mmc0
+        - mmc0boot0
+        - mmc0boot1
+```
+
 ### Rock USB provider (rockusb)
 
 Support for rockchip USB protocol. rockusb devices are autodetected


### PR DESCRIPTION
Boardswarm currently relies on the markdown rendering in GitHub to provide web based documentation. Start creating a more user focused set of documentation that can be exposed on GitHub Pages.