### PR TITLE
Improve udev registration helper

### DIFF
--- a/boardswarm/src/boardswarm_provider/device.rs
+++ b/boardswarm/src/boardswarm_provider/device.rs
@@ -8,7 +8,7 @@ use futures::{pin_mut, Stream, StreamExt};
 use tokio::sync::broadcast;
 use tracing::{trace, warn};
 
-use crate::{DeviceMonitor, DeviceSetModeError};
+use crate::{ConsoleId, DeviceMonitor, DeviceSetModeError, VolumeId};
 
 use super::Provider;
 
@@ -22,8 +22,8 @@ pub struct BoardswarmDevice {
 
 struct BoardswarmDeviceInner {
     // Remote to local mapping
-    console_mapping: HashMap<u64, u64>,
-    volume_mapping: HashMap<u64, u64>,
+    console_mapping: HashMap<u64, ConsoleId>,
+    volume_mapping: HashMap<u64, VolumeId>,
     provider: Arc<Provider>,
     info: boardswarm_protocol::Device,
 }

--- a/boardswarm/src/boardswarm_provider/mod.rs
+++ b/boardswarm/src/boardswarm_provider/mod.rs
@@ -15,6 +15,10 @@ use tonic::transport::Uri;
 use tracing::info;
 use tracing::warn;
 
+use crate::ActuatorId;
+use crate::ConsoleId;
+use crate::DeviceId;
+use crate::VolumeId;
 use crate::{registry::Properties, Server};
 
 use self::actuator::BoardswarmActuator;
@@ -37,10 +41,10 @@ struct BoardswarmParameters {
 
 pub struct Provider {
     /* Remote to local mappings */
-    actuators: Mutex<HashMap<u64, u64>>,
-    consoles: Mutex<HashMap<u64, u64>>,
-    devices: Mutex<HashMap<u64, u64>>,
-    volumes: Mutex<HashMap<u64, u64>>,
+    actuators: Mutex<HashMap<u64, ActuatorId>>,
+    consoles: Mutex<HashMap<u64, ConsoleId>>,
+    devices: Mutex<HashMap<u64, DeviceId>>,
+    volumes: Mutex<HashMap<u64, VolumeId>>,
     notifier: broadcast::Sender<()>,
 }
 
@@ -59,16 +63,16 @@ impl Provider {
         }
     }
 
-    pub fn console_id(&self, remote: u64) -> Option<u64> {
+    pub fn console_id(&self, remote: u64) -> Option<ConsoleId> {
         self.consoles.lock().unwrap().get(&remote).copied()
     }
 
     #[allow(dead_code)]
-    pub fn actuator_id(&self, remote: u64) -> Option<u64> {
+    pub fn actuator_id(&self, remote: u64) -> Option<ActuatorId> {
         self.actuators.lock().unwrap().get(&remote).copied()
     }
 
-    pub fn volume_id(&self, remote: u64) -> Option<u64> {
+    pub fn volume_id(&self, remote: u64) -> Option<VolumeId> {
         self.volumes.lock().unwrap().get(&remote).copied()
     }
 
@@ -127,7 +131,7 @@ fn remove_item(provider: &Provider, type_: ItemType, server: &Server, id: u64) {
         ItemType::Actuator => {
             let mut actuators = provider.actuators.lock().unwrap();
             if let Some(local) = actuators.remove(&id) {
-                server.unregister_console(local)
+                server.unregister_actuator(local)
             }
         }
         ItemType::Device => {

--- a/boardswarm/src/config_device.rs
+++ b/boardswarm/src/config_device.rs
@@ -5,7 +5,8 @@ use tracing::warn;
 
 use crate::{
     registry::{self, Properties, RegistryChange},
-    ActuatorError, Console, DeviceConfigItem, DeviceMonitor, DeviceSetModeError, Server,
+    ActuatorError, ActuatorId, Console, ConsoleId, DeviceConfigItem, DeviceMonitor,
+    DeviceSetModeError, Server, VolumeId,
 };
 
 // TODO deal with closing
@@ -30,10 +31,11 @@ impl DeviceNotifier {
         }
     }
 }
+
 struct DeviceMode {
     name: String,
     depends: Option<String>,
-    sequence: Vec<DeviceItem<u64, crate::config::ModeStep>>,
+    sequence: Vec<DeviceItem<ActuatorId, crate::config::ModeStep>>,
 }
 
 impl From<crate::config::Mode> for DeviceMode {
@@ -101,8 +103,8 @@ struct DeviceInner {
     notifier: DeviceNotifier,
     name: String,
     current_mode: std::sync::Mutex<Option<String>>,
-    consoles: Vec<DeviceItem<u64, crate::config::Console>>,
-    volumes: Vec<DeviceItem<u64, crate::config::Volume>>,
+    consoles: Vec<DeviceItem<ConsoleId, crate::config::Console>>,
+    volumes: Vec<DeviceItem<VolumeId, crate::config::Volume>>,
     modes: Vec<DeviceMode>,
     server: Server,
 }

--- a/boardswarm/src/fastboot.rs
+++ b/boardswarm/src/fastboot.rs
@@ -128,7 +128,7 @@ fn fastboot_volume_target<S: Into<String>>(target: S, size: Option<u64>) -> Volu
 
 #[instrument(skip(r, properties))]
 async fn setup_volume(
-    r: PreRegistration<FastbootVolume>,
+    r: PreRegistration,
     busnum: u8,
     devnum: u8,
     known_targets: Vec<String>,
@@ -187,8 +187,10 @@ async fn setup_volume(
         }
     }
 
-    let volume = FastbootVolume::new(device, max_download, targets);
-    r.register(properties, volume);
+    r.register_volume(
+        properties,
+        FastbootVolume::new(device, max_download, targets),
+    );
     Ok(())
 }
 

--- a/boardswarm/src/gpio.rs
+++ b/boardswarm/src/gpio.rs
@@ -6,6 +6,7 @@ use tokio_gpiod::{Chip, Lines};
 use tracing::instrument;
 use tracing::{debug, warn};
 
+use crate::ActuatorId;
 use crate::{
     registry::{self, Properties},
     udev::DeviceEvent,
@@ -101,7 +102,7 @@ async fn setup_gpio_chip(
     parameters: &GpioParameters,
     mut properties: Properties,
     server: &Server,
-) -> Option<Vec<u64>> {
+) -> Option<Vec<ActuatorId>> {
     let chip = match Chip::new(&path).await {
         Ok(chip) => chip,
         Err(e) => {
@@ -140,7 +141,7 @@ async fn setup_gpio_line(
     name: &str,
     mut properties: Properties,
     server: &Server,
-) -> u64 {
+) -> ActuatorId {
     let info = chip.line_info(line).await.unwrap();
     properties.insert(registry::NAME, name);
     if !info.name.is_empty() {

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -13,6 +13,7 @@ use futures::stream::BoxStream;
 use futures::Sink;
 use mediatek_brom::MediatekBromProvider;
 use registry::{Properties, Registry, RegistryIndex};
+use std::fmt::Display;
 use std::net::{AddrParseError, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -338,7 +339,7 @@ impl From<&dyn Device> for boardswarm_protocol::Device {
             .into_iter()
             .map(|c| boardswarm_protocol::Console {
                 name: c.name,
-                id: c.id,
+                id: c.id.map(Into::into),
             })
             .collect();
         let volumes = d
@@ -346,7 +347,7 @@ impl From<&dyn Device> for boardswarm_protocol::Device {
             .into_iter()
             .map(|v| boardswarm_protocol::Volume {
                 name: v.name,
-                id: v.id,
+                id: v.id.map(Into::into),
             })
             .collect();
         let modes = d
@@ -399,12 +400,12 @@ impl DeviceMonitor {
 
 struct DeviceConsole {
     name: String,
-    id: Option<u64>,
+    id: Option<ConsoleId>,
 }
 
 struct DeviceVolume {
     name: String,
-    id: Option<u64>,
+    id: Option<VolumeId>,
 }
 
 struct DeviceMode {
@@ -423,13 +424,43 @@ trait Device: Send + Sync {
     fn current_mode(&self) -> Option<String>;
 }
 
+macro_rules! impl_u64_index {
+    ($id:ident,$name:ident) => {
+        #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, Ord, PartialEq, Eq)]
+        pub struct $id(u64);
+
+        impl Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, stringify!($name {}), self.0)
+            }
+        }
+
+        impl RegistryIndex for $id {
+            fn next(&self) -> Self {
+                Self(self.0 + 1)
+            }
+        }
+
+        impl From<$id> for u64 {
+            fn from(value: $id) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+impl_u64_index!(ActuatorId, Actuator);
+impl_u64_index!(ConsoleId, Console);
+impl_u64_index!(DeviceId, Device);
+impl_u64_index!(VolumeId, Volume);
+
 struct ServerInner {
     config_dir: PathBuf,
     auth_info: Vec<config::Authentication>,
-    devices: Registry<u64, Arc<dyn Device>>,
-    consoles: Registry<u64, Arc<dyn Console>>,
-    actuators: Registry<u64, Arc<dyn Actuator>>,
-    volumes: Registry<u64, Arc<dyn Volume>>,
+    devices: Registry<DeviceId, Arc<dyn Device>>,
+    consoles: Registry<ConsoleId, Arc<dyn Console>>,
+    actuators: Registry<ActuatorId, Arc<dyn Actuator>>,
+    volumes: Registry<VolumeId, Arc<dyn Volume>>,
 }
 
 fn to_item_list<I, T>(registry: &Registry<I, T>) -> ItemList
@@ -472,7 +503,7 @@ impl Server {
         &self.inner.config_dir
     }
 
-    fn register_actuator<A>(&self, properties: Properties, actuator: A) -> u64
+    fn register_actuator<A>(&self, properties: Properties, actuator: A) -> ActuatorId
     where
         A: Actuator + 'static,
     {
@@ -481,7 +512,7 @@ impl Server {
         id
     }
 
-    fn get_actuator(&self, id: u64) -> Option<Arc<dyn Actuator>> {
+    fn get_actuator(&self, id: ActuatorId) -> Option<Arc<dyn Actuator>> {
         self.inner
             .actuators
             .lookup(id)
@@ -500,14 +531,14 @@ impl Server {
             .map(|(_, item)| item.inner().clone())
     }
 
-    fn unregister_actuator(&self, id: u64) {
+    fn unregister_actuator(&self, id: ActuatorId) {
         if let Some(item) = self.inner.actuators.lookup(id) {
             info!("Unregistering actuator: {} - {}", id, item);
             self.inner.actuators.remove(id);
         }
     }
 
-    fn register_console<C>(&self, properties: Properties, console: C) -> u64
+    fn register_console<C>(&self, properties: Properties, console: C) -> ConsoleId
     where
         C: Console + 'static,
     {
@@ -516,21 +547,21 @@ impl Server {
         id
     }
 
-    fn unregister_console(&self, id: u64) {
+    fn unregister_console(&self, id: ConsoleId) {
         if let Some(item) = self.inner.consoles.lookup(id) {
             info!("Unregistering console: {} - {}", id, item);
             self.inner.consoles.remove(id);
         }
     }
 
-    fn get_console(&self, id: u64) -> Option<Arc<dyn Console>> {
+    fn get_console(&self, id: ConsoleId) -> Option<Arc<dyn Console>> {
         self.inner
             .consoles
             .lookup(id)
             .map(|item| item.inner().clone())
     }
 
-    fn register_volume<V>(&self, properties: Properties, volume: V) -> u64
+    fn register_volume<V>(&self, properties: Properties, volume: V) -> VolumeId
     where
         V: Volume + 'static,
     {
@@ -539,21 +570,21 @@ impl Server {
         id
     }
 
-    fn unregister_volume(&self, id: u64) {
+    fn unregister_volume(&self, id: VolumeId) {
         if let Some(item) = self.inner.volumes.lookup(id) {
             info!("Unregistering volume: {} - {}", id, item.name());
             self.inner.volumes.remove(id);
         }
     }
 
-    pub fn get_volume(&self, id: u64) -> Option<Arc<dyn Volume>> {
+    pub fn get_volume(&self, id: VolumeId) -> Option<Arc<dyn Volume>> {
         self.inner
             .volumes
             .lookup(id)
             .map(registry::Item::into_inner)
     }
 
-    fn register_device<D>(&self, properties: Properties, device: D) -> u64
+    fn register_device<D>(&self, properties: Properties, device: D) -> DeviceId
     where
         D: Device + 'static,
     {
@@ -562,7 +593,7 @@ impl Server {
         id
     }
 
-    fn unregister_device(&self, id: u64) {
+    fn unregister_device(&self, id: DeviceId) {
         if let Some(item) = self.inner.devices.lookup(id) {
             info!("Unregistering device: {} - {}", id, item.name());
             self.inner.devices.remove(id);
@@ -572,7 +603,7 @@ impl Server {
     fn get_device(&self, id: u64) -> Option<Arc<dyn Device>> {
         self.inner
             .devices
-            .lookup(id)
+            .lookup(DeviceId(id))
             .map(registry::Item::into_inner)
     }
 
@@ -703,25 +734,25 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
             boardswarm_protocol::ItemType::Actuator => self
                 .inner
                 .actuators
-                .lookup(request.item)
+                .lookup(ActuatorId(request.item))
                 .ok_or_else(|| tonic::Status::not_found("Item not found"))?
                 .properties(),
             boardswarm_protocol::ItemType::Device => self
                 .inner
                 .devices
-                .lookup(request.item)
+                .lookup(DeviceId(request.item))
                 .ok_or_else(|| tonic::Status::not_found("Item not found"))?
                 .properties(),
             boardswarm_protocol::ItemType::Console => self
                 .inner
                 .consoles
-                .lookup(request.item)
+                .lookup(ConsoleId(request.item))
                 .ok_or_else(|| tonic::Status::not_found("Item not found"))?
                 .properties(),
             boardswarm_protocol::ItemType::Volume => self
                 .inner
                 .volumes
-                .lookup(request.item)
+                .lookup(VolumeId(request.item))
                 .ok_or_else(|| tonic::Status::not_found("Item not found"))?
                 .properties(),
         };
@@ -744,7 +775,8 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<ConsoleConfigureRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
         let inner = request.into_inner();
-        if let Some(console) = self.get_console(inner.console) {
+        let console = ConsoleId(inner.console);
+        if let Some(console) = self.get_console(console) {
             console
                 .configure(Box::new(<dyn erased_serde::Deserializer>::erase(
                     inner.parameters.unwrap(),
@@ -762,7 +794,8 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<ConsoleOutputRequest>,
     ) -> Result<tonic::Response<Self::ConsoleStreamOutputStream>, tonic::Status> {
         let inner = request.into_inner();
-        if let Some(console) = self.get_console(inner.console) {
+        let console = ConsoleId(inner.console);
+        if let Some(console) = self.get_console(console) {
             let stream = console.output_stream().await?;
             Ok(tonic::Response::new(stream))
         } else {
@@ -784,8 +817,8 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         let console = if let Some(console_input_request::TargetOrData::Console(console)) =
             msg.target_or_data
         {
-            self.get_console(console)
-                .ok_or_else(|| tonic::Status::not_found("No serial console by that name"))?
+            self.get_console(ConsoleId(console))
+                .ok_or_else(|| tonic::Status::not_found("No console by that name"))?
         } else {
             return Err(tonic::Status::invalid_argument(
                 "Target should be set first",
@@ -810,8 +843,7 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<boardswarm_protocol::DeviceRequest>,
     ) -> Result<tonic::Response<Self::DeviceInfoStream>, tonic::Status> {
         let request = request.into_inner();
-        if let Some(item) = self.inner.devices.lookup(request.device) {
-            let device = item.into_inner();
+        if let Some(device) = self.get_device(request.device) {
             let info = (&*device).into();
             let monitor = device.updates();
             let stream = Box::pin(stream::once(async move { Ok(info) }).chain(stream::unfold(
@@ -856,7 +888,8 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<boardswarm_protocol::ActuatorModeRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
         let inner = request.into_inner();
-        if let Some(actuator) = self.get_actuator(inner.actuator) {
+        let actuator = ActuatorId(inner.actuator);
+        if let Some(actuator) = self.get_actuator(actuator) {
             actuator
                 .set_mode(Box::new(<dyn erased_serde::Deserializer>::erase(
                     inner.parameters.unwrap(),
@@ -885,11 +918,9 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         };
 
         if let Some(volume_io_request::TargetOrRequest::Target(target)) = msg.target_or_request {
+            let volume = VolumeId(target.volume);
             let volume = self
-                .inner
-                .volumes
-                .lookup(target.volume)
-                .map(registry::Item::into_inner)
+                .get_volume(volume)
                 .ok_or_else(|| tonic::Status::not_found("No volume by that name"))?;
 
             let (mut reply, reply_stream) = VolumeIoReplies::new();
@@ -955,8 +986,9 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<VolumeRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
         let request = request.into_inner();
+        let volume = VolumeId(request.volume);
         let volume = self
-            .get_volume(request.volume)
+            .get_volume(volume)
             .ok_or_else(|| tonic::Status::not_found("Volume not found"))?;
         volume.commit().await?;
         Ok(tonic::Response::new(()))
@@ -967,8 +999,9 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<VolumeEraseRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
         let request = request.into_inner();
+        let volume = VolumeId(request.volume);
         let volume = self
-            .get_volume(request.volume)
+            .get_volume(volume)
             .ok_or_else(|| tonic::Status::not_found("Volume not found"))?;
         volume.erase(&request.target).await?;
         Ok(tonic::Response::new(()))
@@ -979,8 +1012,9 @@ impl boardswarm_protocol::boardswarm_server::Boardswarm for Server {
         request: tonic::Request<VolumeRequest>,
     ) -> Result<tonic::Response<VolumeInfoMsg>, tonic::Status> {
         let request = request.into_inner();
+        let volume = VolumeId(request.volume);
         let volume = self
-            .get_volume(request.volume)
+            .get_volume(volume)
             .ok_or_else(|| tonic::Status::not_found("Volume not found"))?;
 
         let (target, exhaustive) = volume.targets();

--- a/boardswarm/src/mediatek_brom.rs
+++ b/boardswarm/src/mediatek_brom.rs
@@ -18,7 +18,7 @@ pub const TARGET: &str = "brom";
 
 pub struct MediatekBromProvider {
     name: String,
-    registrations: DeviceRegistrations<MediatekBromVolume>,
+    registrations: DeviceRegistrations,
 }
 
 impl MediatekBromProvider {
@@ -63,11 +63,7 @@ impl SerialProvider for MediatekBromProvider {
 }
 
 #[instrument(skip(r, properties))]
-async fn setup_volume(
-    r: PreRegistration<MediatekBromVolume>,
-    node: PathBuf,
-    mut properties: Properties,
-) {
+async fn setup_volume(r: PreRegistration, node: PathBuf, mut properties: Properties) {
     info!("Setting up brom volume for {}", node.display());
     let mut port = match tokio_serial::new(node.to_string_lossy(), 115200).open_native_async() {
         Ok(port) => port,
@@ -102,9 +98,7 @@ async fn setup_volume(
         format!("{}", hwcode.version),
     );
 
-    let volume = MediatekBromVolume::new(port, brom);
-
-    r.register(properties, volume);
+    r.register_volume(properties, MediatekBromVolume::new(port, brom));
 }
 
 enum BromCommand {

--- a/boardswarm/src/udev.rs
+++ b/boardswarm/src/udev.rs
@@ -8,14 +8,14 @@ use std::{
     task::Poll,
 };
 
-use crate::{registry::Properties, Server};
+use crate::{registry::Properties, Server, VolumeId};
 use futures::{ready, Stream};
 use tokio_udev::{AsyncMonitorSocket, Enumerator};
 use tracing::{info, warn};
 
 trait Registrations<IT> {
-    fn register(&self, properties: Properties, item: IT) -> u64;
-    fn unregister(&self, id: u64);
+    fn register(&self, properties: Properties, item: IT) -> VolumeId;
+    fn unregister(&self, id: VolumeId);
 }
 
 #[derive(Debug)]
@@ -23,7 +23,7 @@ enum RegistrationState {
     /// Pending registration for a given udev sequence number
     Pending(u64),
     /// Registered with volume id
-    Registered(u64),
+    Registered(VolumeId),
 }
 
 pub struct DeviceRegistrations<IT> {
@@ -88,11 +88,11 @@ impl<IT> Registrations<IT> for DeviceRegistrations<IT>
 where
     IT: crate::Volume + 'static,
 {
-    fn register(&self, properties: Properties, item: IT) -> u64 {
+    fn register(&self, properties: Properties, item: IT) -> VolumeId {
         self.server.register_volume(properties, item)
     }
 
-    fn unregister(&self, id: u64) {
+    fn unregister(&self, id: VolumeId) {
         self.server.unregister_volume(id);
     }
 }

--- a/boardswarm/src/udev.rs
+++ b/boardswarm/src/udev.rs
@@ -1,21 +1,22 @@
 use std::{
     collections::{HashMap, VecDeque},
     ffi::OsStr,
-    marker::PhantomData,
     path::{Path, PathBuf},
     pin::Pin,
     sync::{Arc, Mutex},
     task::Poll,
 };
 
-use crate::{registry::Properties, Server, VolumeId};
+use crate::{registry::Properties, ActuatorId, ConsoleId, Server, VolumeId};
 use futures::{ready, Stream};
 use tokio_udev::{AsyncMonitorSocket, Enumerator};
 use tracing::{info, warn};
 
-trait Registrations<IT> {
-    fn register(&self, properties: Properties, item: IT) -> VolumeId;
-    fn unregister(&self, id: VolumeId);
+#[derive(Debug, Clone, Copy)]
+enum Registration {
+    Actuator(ActuatorId),
+    Console(ConsoleId),
+    Volume(VolumeId),
 }
 
 #[derive(Debug)]
@@ -23,50 +24,35 @@ enum RegistrationState {
     /// Pending registration for a given udev sequence number
     Pending(u64),
     /// Registered with volume id
-    Registered(VolumeId),
+    Registered(Vec<Registration>),
 }
 
-pub struct DeviceRegistrations<IT> {
+#[derive(Clone)]
+pub struct DeviceRegistrations {
     server: Server,
     registrations: Arc<Mutex<HashMap<PathBuf, RegistrationState>>>,
-    marker: PhantomData<IT>,
 }
 
-impl<IT> Clone for DeviceRegistrations<IT> {
-    fn clone(&self) -> Self {
-        Self {
-            server: self.server.clone(),
-            registrations: self.registrations.clone(),
-            marker: PhantomData,
-        }
-    }
-}
-
-#[allow(private_bounds)]
-impl<IT> DeviceRegistrations<IT>
-where
-    DeviceRegistrations<IT>: Registrations<IT>,
-{
+impl DeviceRegistrations {
     pub fn new(server: Server) -> Self {
         DeviceRegistrations {
             server,
             registrations: Default::default(),
-            marker: PhantomData,
         }
     }
 
     /// Mark a device as being a prepared for final registration. This ensures on the iteration
     /// with the given sequence number can get registered, avoiding races where a device disappears
     /// and re-appears while the preperation process is ongoing
-    pub fn pre_register(&self, device: &Device, seqnum: u64) -> PreRegistration<IT> {
+    pub fn pre_register(&self, device: &Device, seqnum: u64) -> PreRegistration {
         let mut registrations = self.registrations.lock().unwrap();
         let syspath = device.syspath().to_path_buf();
         if let Some(existing) =
             registrations.insert(syspath.clone(), RegistrationState::Pending(seqnum))
         {
             warn!("Pre-registering with known previous item: {:?}", existing);
-            if let RegistrationState::Registered(id) = existing {
-                self.unregister(id);
+            if let RegistrationState::Registered(registrations) = existing {
+                self.unregister(registrations);
             }
         }
         PreRegistration {
@@ -78,58 +64,127 @@ where
 
     pub fn remove(&self, device: &Device) {
         let mut registrations = self.registrations.lock().unwrap();
-        if let Some(RegistrationState::Registered(id)) = registrations.remove(device.syspath()) {
-            self.unregister(id);
+        if let Some(RegistrationState::Registered(registrations)) =
+            registrations.remove(device.syspath())
+        {
+            self.unregister(registrations);
+        }
+    }
+
+    fn unregister(&self, registrations: Vec<Registration>) {
+        for r in registrations {
+            match r {
+                Registration::Actuator(id) => self.server.unregister_actuator(id),
+                Registration::Console(id) => self.server.unregister_console(id),
+                Registration::Volume(id) => self.server.unregister_volume(id),
+            }
         }
     }
 }
 
-impl<IT> Registrations<IT> for DeviceRegistrations<IT>
-where
-    IT: crate::Volume + 'static,
-{
-    fn register(&self, properties: Properties, item: IT) -> VolumeId {
-        self.server.register_volume(properties, item)
+pub struct RegistrationGuard<'a> {
+    server: &'a Server,
+    registrations: Vec<Registration>,
+}
+
+impl RegistrationGuard<'_> {
+    pub fn register_actuator<A>(&mut self, properties: Properties, item: A)
+    where
+        A: crate::Actuator + 'static,
+    {
+        let id = self.server.register_actuator(properties, item);
+        self.registrations.push(Registration::Actuator(id));
     }
 
-    fn unregister(&self, id: VolumeId) {
-        self.server.unregister_volume(id);
+    pub fn register_console<C>(&mut self, properties: Properties, item: C)
+    where
+        C: crate::Console + 'static,
+    {
+        let id = self.server.register_console(properties, item);
+        self.registrations.push(Registration::Console(id));
+    }
+
+    pub fn register_volume<V>(&mut self, properties: Properties, item: V)
+    where
+        V: crate::Volume + 'static,
+    {
+        let id = self.server.register_volume(properties, item);
+        self.registrations.push(Registration::Volume(id));
     }
 }
 
-#[allow(private_bounds)]
-pub struct PreRegistration<IT>
-where
-    DeviceRegistrations<IT>: Registrations<IT>,
-{
+/// Tracking struct for a device before it's ready to be registered
+pub struct PreRegistration {
     syspath: PathBuf,
     seqnum: u64,
-    pending: DeviceRegistrations<IT>,
+    pending: DeviceRegistrations,
 }
 
-#[allow(private_bounds)]
-impl<IT> PreRegistration<IT>
-where
-    DeviceRegistrations<IT>: Registrations<IT>,
-{
-    pub fn register(self, properties: Properties, item: IT) {
+impl PreRegistration {
+    /// Register all items for a device
+    ///
+    /// When a device is meant to expose multiple items, these can be registered as a batch. The
+    /// passed function should only take care of registration and more importantly not block
+    ///
+    /// ```
+    /// prereg.register_batch(| r | {
+    ///   r.register_actuator(actuator_props, actuator);
+    ///   r.register_console(console_props, console);
+    /// });
+    /// ```
+    pub fn register_batch<F>(self, r: F)
+    where
+        F: FnOnce(&mut RegistrationGuard),
+    {
         let mut registrations = self.pending.registrations.lock().unwrap();
         match registrations.get(&self.syspath) {
             Some(RegistrationState::Pending(s)) if *s == self.seqnum => {
-                let id = self.pending.register(properties, item);
-                registrations.insert(self.syspath.clone(), RegistrationState::Registered(id));
+                let mut guard = RegistrationGuard {
+                    server: &self.pending.server,
+                    registrations: vec![],
+                };
+
+                r(&mut guard);
+
+                registrations.insert(
+                    self.syspath.clone(),
+                    RegistrationState::Registered(guard.registrations),
+                );
             }
             _ => {
                 info!("Ignoring outdated registration (seqnum: {})", self.seqnum)
             }
         }
     }
+
+    #[allow(dead_code)]
+    /// Register a single actuator
+    pub fn register_actuator<A>(self, properties: Properties, item: A)
+    where
+        A: crate::Actuator + 'static,
+    {
+        self.register_batch(|r| r.register_actuator(properties, item));
+    }
+
+    #[allow(dead_code)]
+    /// Register a single console
+    pub fn register_console<C>(self, properties: Properties, item: C)
+    where
+        C: crate::Console + 'static,
+    {
+        self.register_batch(|r| r.register_console(properties, item));
+    }
+
+    /// Register a single volume
+    pub fn register_volume<V>(self, properties: Properties, item: V)
+    where
+        V: crate::Volume + 'static,
+    {
+        self.register_batch(|r| r.register_volume(properties, item));
+    }
 }
 
-impl<IT> Drop for PreRegistration<IT>
-where
-    DeviceRegistrations<IT>: Registrations<IT>,
-{
+impl Drop for PreRegistration {
     fn drop(&mut self) {
         let mut registrations = self.pending.registrations.lock().unwrap();
         match registrations.get(&self.syspath) {


### PR DESCRIPTION
the registration helper was rather limited; Only volume's could be registered with it and at most one of those. Extend that so it can be used for any type as well as supporting multiple items to be registered in a batch

This also refactors the registry indexing so they can be typed rather then just u64, which makes it very explicit what an id refers to. 