### PR TITLE
chore: boardswarm: Remove left-over jwks warning

### DIFF
--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -1011,7 +1011,6 @@ async fn setup_auth_layer(
                     .await?
             }
             config::Authentication::Jwks { path } => {
-                warn!("No local jwks support yet");
                 let jwks = tokio::fs::read_to_string(path).await?;
                 TenantConfiguration::static_builder(jwks).build()?
             }


### PR DESCRIPTION
Seemingly this warning was left in while refactoring to a different jwk auth provider. Drop it as it's both confusing and wrong :)