### PR TITLE
boardswarm: Add hifive-p550-storage provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "mediatek-brom",
  "nusb",
  "pdudaemon-client",
+ "proc-mounts",
  "regex",
  "reqwest",
  "rockusb",
@@ -888,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2155,6 +2156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "partition-identity"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-mounts"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d652f8435d0ab70bf4f3590a6a851d59604831a458086541b95238cc51ffcf2"
+dependencies = [
+ "partition-identity",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,7 +2554,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2833,7 +2852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2846,7 +2865,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3334,7 +3353,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/boardswarm/Cargo.toml
+++ b/boardswarm/Cargo.toml
@@ -45,3 +45,4 @@ reqwest = { version = "0.12.15", default-features = false, features = ["rustls-t
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 regex = "1.11.1"
+proc-mounts = "0.3.0"

--- a/boardswarm/src/eswin_eic7700_storage.rs
+++ b/boardswarm/src/eswin_eic7700_storage.rs
@@ -1,0 +1,230 @@
+use bytes::Bytes;
+use proc_mounts::{MountInfo, MountIter};
+use serde::Deserialize;
+use std::{
+    collections::HashMap,
+    io::SeekFrom,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio_stream::StreamExt;
+use tracing::{debug, instrument, trace, warn};
+
+use crate::{
+    registry::{self, Properties},
+    udev::{DeviceEvent, DeviceRegistrations, PreRegistration},
+    Server, Volume, VolumeError, VolumeTarget, VolumeTargetInfo,
+};
+
+pub const PROVIDER: &str = "eswin-eic7700-storage";
+
+const MOUNT_TIMEOUT: Duration = Duration::from_secs(10);
+const MOUNT_INTERVAL: Duration = Duration::from_secs(1);
+
+const TARGET_BOOTLOADER: (&str, &str) = ("bootloader", "bootloader_ddr5_secboot.bin");
+
+#[derive(Deserialize, Debug, Default)]
+struct EswinEic7700StorageParameters {
+    #[serde(rename = "match")]
+    match_: HashMap<String, String>,
+    mountpoint: String,
+}
+
+#[instrument(skip(server, parameters))]
+pub async fn start_provider(name: String, parameters: Option<serde_yaml::Value>, server: Server) {
+    let registrations = DeviceRegistrations::new(server);
+    let provider_properties = &[
+        (registry::PROVIDER_NAME, name.as_str()),
+        (registry::PROVIDER, PROVIDER),
+    ];
+    let mut devices = crate::udev::DeviceStream::new("block").unwrap();
+    let parameters: EswinEic7700StorageParameters = if let Some(parameters) = parameters {
+        serde_yaml::from_value(parameters).unwrap()
+    } else {
+        Default::default()
+    };
+    while let Some(d) = devices.next().await {
+        match d {
+            DeviceEvent::Add { device, seqnum } => {
+                let mut properties = device.properties(&name);
+                if !properties.matches(&parameters.match_) {
+                    debug!(
+                        "Ignoring device {} - {:?}",
+                        device.syspath().display(),
+                        properties,
+                    );
+                    continue;
+                }
+                properties.extend(provider_properties);
+
+                let prereg = registrations.pre_register(&device, seqnum);
+                let mountpoint = parameters.mountpoint.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = setup_volume(prereg, Path::new(&mountpoint), properties).await {
+                        warn!("Failed to setup volume: {e}");
+                    }
+                });
+            }
+            DeviceEvent::Remove(device) => registrations.remove(&device),
+        }
+    }
+}
+
+#[instrument(skip(r, properties))]
+async fn setup_volume(
+    r: PreRegistration,
+    mountpoint: &Path,
+    properties: Properties,
+) -> anyhow::Result<()> {
+    let devname = properties
+        .get("udev.DEVNAME")
+        .ok_or_else(|| anyhow::anyhow!("Failed to read udev property DEVNAME"))?;
+    let id = properties
+        .get("udev.ID_PATH")
+        .ok_or_else(|| anyhow::anyhow!("Failed to read udev property ID_PATH"))?;
+    let path = tokio::fs::canonicalize(mountpoint).await?.join(id);
+    tokio::time::timeout(
+        MOUNT_TIMEOUT,
+        wait_mount(
+            Path::new(devname),
+            &path,
+            tokio::time::interval(MOUNT_INTERVAL),
+        ),
+    )
+    .await??;
+    r.register_volume(properties, EswinEic7700StorageVolume::new(path));
+    Ok(())
+}
+
+#[instrument(skip(interval_))]
+async fn wait_mount(
+    source: &Path,
+    dest: &Path,
+    mut interval_: tokio::time::Interval,
+) -> anyhow::Result<MountInfo> {
+    loop {
+        trace!("Waiting mount point");
+        for mount in MountIter::new()? {
+            let mount = mount?;
+            if mount.source == source && mount.dest == dest {
+                trace!("Found mount point: {:?}", mount);
+                return Ok(mount);
+            }
+        }
+        interval_.tick().await;
+    }
+}
+
+#[derive(Debug)]
+pub struct EswinEic7700StorageVolume {
+    path: PathBuf,
+    targets: Vec<VolumeTargetInfo>,
+}
+
+impl EswinEic7700StorageVolume {
+    fn new(path: PathBuf) -> Self {
+        let (name, _) = TARGET_BOOTLOADER;
+        let target = VolumeTargetInfo {
+            name: name.to_string(),
+            readable: false,
+            writable: true,
+            seekable: true,
+            size: None,
+            blocksize: None,
+        };
+        Self {
+            path,
+            targets: vec![target],
+        }
+    }
+}
+
+impl From<std::io::Error> for crate::VolumeError {
+    fn from(e: std::io::Error) -> Self {
+        crate::VolumeError::Internal(e.to_string())
+    }
+}
+
+#[async_trait::async_trait]
+impl Volume for EswinEic7700StorageVolume {
+    fn targets(&self) -> (&[VolumeTargetInfo], bool) {
+        (self.targets.as_slice(), true)
+    }
+
+    async fn open(
+        &self,
+        target: &str,
+        _length: Option<u64>,
+    ) -> Result<(VolumeTargetInfo, Box<dyn VolumeTarget>), VolumeError> {
+        if let Some(volume_target) = self.targets.iter().find(|t| t.name == target) {
+            let (_, filename) = TARGET_BOOTLOADER;
+            let path = self.path.join(filename);
+            let file = tokio::fs::File::create(path).await?;
+            Ok((
+                volume_target.clone(),
+                Box::new(EswinEic7700StorageTarget { file }),
+            ))
+        } else {
+            warn!("Unknown target requested");
+            Err(VolumeError::UnknownTargetRequested)
+        }
+    }
+
+    async fn commit(&self) -> Result<(), VolumeError> {
+        // Once the file is written to the filesystem, the board runs the
+        // bootstrapping sequence (loads bootloader firmware file in memory,
+        // unregisters usb mass-storage device and jumps into the loaded
+        // bootloader). This is guaranteed to happen by the flush/shutdown calls
+        // on the VolumeTarget. There's no further action to be run on commit,
+        // e.g. sync or umount calls won't make the board to reboot.
+        Ok(())
+    }
+}
+
+struct EswinEic7700StorageTarget {
+    file: tokio::fs::File,
+}
+
+impl std::fmt::Debug for EswinEic7700StorageTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO make more meaningful
+        f.debug_struct("EswinEic7700StorageTarget")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl VolumeTarget for EswinEic7700StorageTarget {
+    async fn write(&mut self, data: Bytes, offset: u64, completion: crate::WriteCompletion) {
+        if let Err(e) = self.file.seek(SeekFrom::Start(offset)).await {
+            completion.complete(Err(tonic::Status::internal(e.to_string())));
+            return;
+        };
+        completion.complete(
+            self.file
+                .write_all(&data)
+                .await
+                .map_err(|e| tonic::Status::internal(e.to_string()))
+                .and(Ok(data.len() as u64)),
+        );
+    }
+
+    async fn flush(&mut self, completion: crate::FlushCompletion) {
+        completion.complete(
+            self.file
+                .flush()
+                .await
+                .map_err(|e| tonic::Status::internal(e.to_string())),
+        );
+    }
+
+    async fn shutdown(&mut self, completion: crate::ShutdownCompletion) {
+        completion.complete(
+            self.file
+                .shutdown()
+                .await
+                .map_err(|e| tonic::Status::internal(e.to_string())),
+        );
+    }
+}

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -32,6 +32,7 @@ mod boardswarm_provider;
 mod config;
 mod config_device;
 mod dfu;
+mod eswin_eic7700_storage;
 mod fastboot;
 mod gpio;
 mod hifive_p550_mcu;
@@ -1158,6 +1159,13 @@ async fn main() -> anyhow::Result<()> {
             }
             fastboot::PROVIDER => {
                 local.spawn_local(fastboot::start_provider(
+                    p.name,
+                    p.parameters,
+                    server.clone(),
+                ));
+            }
+            eswin_eic7700_storage::PROVIDER => {
+                local.spawn_local(eswin_eic7700_storage::start_provider(
                     p.name,
                     p.parameters,
                     server.clone(),


### PR DESCRIPTION
```
    boardswarm: Add eswin-eic7700-storage provider
    
    The eswin-eic7700-storage provider registers a volume with a single
    target `bootloader`.
    
    When in USB download mode, the ESWIN EIC7700X will register itself as a
    mass storage device. When the `bootloader_ddr5_secboot.bin` bootloader
    artifact is written to its filesystem, it will automatically unregister
    and bootstrap into this bootloader image.
    
    Writing to the volume target `bootloader` will create and write the
    content to this file `bootloader_ddr5_secboot.bin`.
    
    Example server configuration (HiFive Premier P550 Development Board):
    ```
    providers:
      - name: eswin-eic7700-storage
        provider: eswin-eic7700-storage
        parameters:
          match:
            udev.ID_VENDOR: "ESWIN"
            udev.ID_MODEL: "WIN-2030"
          mountpoint: "/var/run/boardswarm/eswin-eic7700-storage"
    
    devices:
      - name: sifive-hifive-p550-evk-cbg-0
        consoles:
        volumes:
          - name: storage
            match:
              udev.ID_PATH: "pci-0000:02:00.2-usb-0:1.1.2:1.0-scsi-0:0:0:0"
    ```
    
    The user running boardswarm need to have access to the directory where
    the storage device is mounted.
    
    For example, a udev rule like the following could be added to automount
    the device using systemd-mount:
    ```
    $ cat /etc/udev/rules.d/99-boardswarm.rules
    ACTION=="add", SUBSYSTEMS=="usb", SUBSYSTEM=="block", \
        ENV{ID_VENDOR}=="ESWIN", ENV{ID_MODEL}=="WIN-2030", TAG+="systemd", \
        RUN{program}+="/usr/bin/systemd-mount --owner=boardswarm --no-block --automount=no --collect \
        $devnode /var/run/boardswarm/eswin-eic7700-storage/$env{ID_PATH}"
    ```
    
    Signed-off-by: Ariel D'Alessandro <ariel.dalessandro@collabora.com>
```