### PR TITLE
Add draft of Boardswarm website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,27 @@
+name: website
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme
+      - name: Sphinx build
+        run: |
+          sphinx-build website _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/website/conf.py
+++ b/website/conf.py
@@ -1,0 +1,47 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Boardswarm'
+copyright = 'Boardswarm authors'
+author = 'Boardswarm authors'
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+#extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# Add the extension
+extensions = [
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
+]
+
+# Make sure the target is unique
+autosectionlabel_prefix_document = True
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+html_theme_options = {
+    'prev_next_buttons_location': None,
+}
+
+html_context = {
+  'display_github': True,
+  'github_user': 'boardswarm',
+  'github_repo': 'boardswarm',
+  'github_version': 'main/website/',
+}

--- a/website/guides/basic-functionality.rst
+++ b/website/guides/basic-functionality.rst
@@ -1,0 +1,64 @@
+===================
+Basic Functionality
+===================
+
+Listing available devices
+=========================
+
+The boards available on the boardswarm server can be listed with the following
+command::
+
+   $ boardswarm-cli list devices
+
+This command provides a list of the board IDs and names.
+
+
+Terminal style access to the board
+==================================
+
+The console UI is the main way to interact with development boards hosted on a
+Boardswarm server. This UI can be launched with the following command::
+
+   $ boardswarm-cli ui <device name or id>
+
+Where the device name or ID is one from the previous command.
+
+The UI has 2 modes, console and command. The console mode allows the user to
+interact with the serial console of the remote board. In the command mode the
+user can perform boardswarm specific operations. When launching the Boardswarm
+UI it is initially in the console mode. The command mode can be entered by
+sending ``<ctrl>-a`` (abbreviated below as ``^a``). This is typically followed by
+one of the below commands. The connection will stay in command mode until ``ESC``
+is sent.
+
+the follow commands are available:
+
+=== ====================================================================
+Key Command mode binding
+=== ====================================================================
+q   Quit the ui
+o   Change the device to mode "on"
+f   Change the device to mode "off"
+r   Reset the device's power (same as changing mode to "off" then "on")
+k   Scroll up
+j   Scroll down
+0   Reset scrolling state
+ESC Leave command mode
+=== ====================================================================
+
+
+Changing power state outside of the console UI
+==============================================
+
+The power state of a board can be changed from the commandline via the
+``device`` ``mode`` subcommand::
+
+    $ boardswarm-cli device <device name or id> mode <mode>
+
+It is typical for a devices config to provide ``on`` and ``off`` modes, but
+this is convention rather than required. The following command can be used to
+list basic information about a boards configuration, including the available
+modes (in JSON format)::
+
+    $ boardswarm-cli device <device name or id> info
+

--- a/website/guides/setup-client.rst
+++ b/website/guides/setup-client.rst
@@ -1,0 +1,5 @@
+==============================
+Setting up a Boardswarm client
+==============================
+
+Installing and configuring a Boardswarm client is currently documented in the `boardswarm client documentation <https://github.com/boardswarm/boardswarm/blob/main/boardswarm-cli/README.md>`_.

--- a/website/guides/setup-server.rst
+++ b/website/guides/setup-server.rst
@@ -1,0 +1,5 @@
+==============================
+Setting up a Boardswarm server
+==============================
+
+Installing and configuring a Boardswarm server is currently documented in the `boardswarm server documentation <https://github.com/boardswarm/boardswarm/blob/main/boardswarm/README.md>`_.

--- a/website/index.rst
+++ b/website/index.rst
@@ -1,0 +1,37 @@
+
+==========
+Boardswarm
+==========
+
+Boardswarm provides a distributed service to interact with development boards.
+It is able to interact with the boards via their serial consoles, manage power,
+auxillary control lines and using a growing number of protocols, such as:
+
+- Device Firmware Upgrade (DFU)
+- Fastboot
+- MediaTek Boot ROM protocol
+- Rockchip USB protocol
+
+The connection between the boardswarm server and client application can be
+secured using multiple authentication mechanisms.
+
+
+Where can I get Boardswarm?
+===========================
+
+Boardswarm is a relatively new project and under active development. The latest releases, built by the projects CI build process can be found here:
+
+  https://github.com/boardswarm/boardswarm/releases/tag/latest
+
+Full source code can be found in our github repository:
+
+  https://github.com/boardswarm/boardswarm
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   guides/setup-server.rst
+   guides/setup-client.rst
+   guides/basic-functionality.rst


### PR DESCRIPTION
First draft of Boardswarm website. covering where to find the code, pointers to existing configuration documentation and a very short users guide.