### PR TITLE
Use official actions for pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   docs:
@@ -17,11 +19,20 @@ jobs:
       - name: Sphinx build
         run: |
           sphinx-build website _build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          force_orphan: true
+          path: _build/
+
+  deploy:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
peaceiris/actions-gh-pages@v3 seems to want to push to a github branch and publish from that. Use the official actions instead to publish an artifact and deploy that on github pages, without the need for a branch