### PR TITLE
boardswarm-cli: Fix misaligned volumes in device info

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -986,7 +986,7 @@ async fn print_device(
                 println!();
             }
         } else {
-            println!(" * {} - not available", v.name);
+            println!("- {} - not available", v.name);
         }
     }
     Ok(())


### PR DESCRIPTION
In the recently added device info output, the volumes are not equally aligned. Those not available should be aligned as the others. Fix this.

```
$ boardswarm-cli -i sjic device sifive-hifive-p550-evk-cbg-0 info
Current mode: download
Modes:
- off
- on (depends on off)
- download (depends on off)
Consoles:
- main - id: 241
Volumes:
 * fastboot - not available
- storage - id: 53, targets:
  + bootloader (writable, seekable)
```