### PR TITLE
boardswarm: README: use 'auth' instead of 'configure'

### DIFF
--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -54,7 +54,7 @@ server:
 On the client side to set up such a server run the following command and follow
 the instructions to authenticate:
 ```
-$ boardswarm-cli  --instance <instance name> configure --new  -u <instance url>
+$ boardswarm-cli --instance <instance name> auth init -u <instance url>
 ```
 
 ### Static JWKS based authentication
@@ -94,7 +94,7 @@ $ rnbyc -s '{"exp": 1798761600}' -K private.jwks > token.jwt
 On the client side to set up such a server run the following command and follow
 the instructions to authenticate:
 ```
-$ boardswarm-cli  --instance <instance name> configure --new -u <instance url> --token-file <path to token file>
+$ boardswarm-cli --instance <instance name> auth init -u <instance url> --token-file <path to token file>
 ```
 
 ## Providers


### PR DESCRIPTION
Commit 646c456 fixed the authentication setup steps in boardswarm-cli/README.md but left out the duplicated commands in boardswarm/README.md.
Fix them as well to use 'auth' instead of 'configure'.

Fixes: 646c456 ("cli: Update the README to use 'auth' instead of 'configure'")

Note: Alternatively, we could describe the client-side authentication step only in boardswarm-cli/README.md and point to that section from boardswarm/README.md. Pro: delete redundancy that lead to this inconsistency. Con: need to jump from one document to the other, as usually you would set up the server and immediately test it with the client. Let me know what you prefer.