### PR TITLE
Add python scripting page

### DIFF
--- a/website/guides/python-scripting.rst
+++ b/website/guides/python-scripting.rst
@@ -1,0 +1,44 @@
+===========================================
+Automating tasks with Python and Boardswarm
+===========================================
+
+There are frequently times during development or when debugging an issue when
+having the ability to automate frequently performed tasks or create a quick
+script to loop testing a device that occasionaly fails can be really
+beneficial. If the devices are already being used in boardswarm, doing this can
+be trivial.
+
+Here's a quick example using `Python <https://www.python.org/>`_ and
+`pexpect <https://pexpect.readthedocs.io/en/stable/>`_, which powers up a
+board, waits for a login prompt, logs in and powers the machine back off. (Not
+particularly useful in this form, I know, but it does form the basis for a
+number of tasks)::
+
+    #!/usr/bin/python3
+    import os
+    import pexpect
+    import time
+    
+    device="<your devices name here>"
+    
+    # Ensure device is off
+    os.system(f'boardswarm-cli device {device} mode off')
+    
+    # Attach console
+    child = pexpect.spawn(f'boardswarm-cli device {device} connect')
+    
+    # Power up board
+    os.system(f'boardswarm-cli device {device} mode on')
+    
+    match = child.expect(["login:"], timeout=120)
+    
+    child.send("user\n")
+    child.expect(["Password:"])
+    
+    child.send("user\n")
+    time.sleep(4)
+    child.expect(['$'])
+    
+    child.send("sudo poweroff\n")
+    child.expect(["reboot: Power down"])
+

--- a/website/index.rst
+++ b/website/index.rst
@@ -35,3 +35,4 @@ Full source code can be found in our github repository:
    guides/setup-server.rst
    guides/setup-client.rst
    guides/basic-functionality.rst
+   guides/python-scripting.rst


### PR DESCRIPTION
This may not be the most elegant way to perform testing using Boardswarm, however it did allow me to fairly efficiently run some one-off testing that I needed to perform and I can see myself taking this approach again when I have some tasks that I wish to perform on boards connected to boardswarm, unless of course a better alternative is shown to be in the meantime.