### PR TITLE
Add GPIO control documentation

### DIFF
--- a/website/guides/gpio-control.rst
+++ b/website/guides/gpio-control.rst
@@ -1,0 +1,26 @@
+============
+GPIO control
+============
+
+Controlling specific GPIOS directly
+===================================
+
+GPIOs can be hooked up to ancillary signals which can be used to put the board
+into alternative states, such as a download mode. GPIOs fall under the category
+of "actuators", the available actuators can be listed with the following
+command::
+
+    $ boardswarm-cli list actuators
+
+This list will include all the actuators available, which will include any
+switchable PSU ports, etc. Take care to ensure you are not switching an
+actuator assigned to another device.
+
+The ``actuators`` command provides the ``change-mode`` sub-command. This takes
+an "Actuator specific mode in json format". GPIOs expect a field named
+``value``, with a boolean value. So to enable a GPIO::
+
+    $ boardswarm-cli actuator <actuator name or id> change-mode '{"value": true}'
+
+
+

--- a/website/index.rst
+++ b/website/index.rst
@@ -35,3 +35,4 @@ Full source code can be found in our github repository:
    guides/setup-server.rst
    guides/setup-client.rst
    guides/basic-functionality.rst
+   guides/gpio-control.rst


### PR DESCRIPTION
Some very basic documentation on how to drive GPIOs. This is certainly not the most ideal way to drive a GPIO, however I currently haven't found a better way to drive an arbitrary GPIO line (say one hooked up to a user definable GPIO input). The syntax required for `<MODE>` wasn't obvious as a user, hence documenting this for others.