### PR TITLE
Add page for Mediatek boards

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme
+          pip install sphinx sphinx_rtd_theme sphinx_toolbox
       - name: Sphinx build
         run: |
           sphinx-build website _build

--- a/website/boards/mediatek.rst
+++ b/website/boards/mediatek.rst
@@ -1,0 +1,311 @@
+========
+MediaTek
+========
+
+Genio 700 EVK
+=============
+
+This is a quick guide covering options available for configuring the MediaTek
+Genio 700 EVK. The official guide to connecting the board to a host can be
+found here:
+
+https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/get-started/connect.html
+
+
+Setting up serial
+-----------------
+
+.. note::
+  .. collapse:: Ensure server is configured to allow boardswarm to access USB serial devices
+
+    .. include:: ../guides/sections/serial_udev.rst
+
+
+
+.. tip::
+  .. include:: ../guides/sections/serial_identification.rst
+
+Connect a microUSB cable to ``UART0`` on the EVK and the other end to the
+boardswarm server.
+
+Create a node under ``devices`` for the board and add a console node, also
+specifying the baud rate, which is 921600bps::
+
+   devices:
+     - name: genio-700-1
+       consoles:
+         - name: main
+           parameters:
+             rate: 921600
+           match:
+             udev.ID_USB_SERIAL: "FTDI_FT232R_UB_UART_<serial>"
+
+
+Setting up power
+----------------
+
+Board is powered with 12V via ``DC IN`` barrel jack. In order for the device to
+boot when power is applied, either a USB cable needs to be powered and
+connected to the ``Micro USB D/L`` port, or the power GPIO needs to be toggled
+on and off (see GPIO setup below for more information).
+
+For now we will assume that a cable has plugged into the ``Micro USB D/L`` port
+and we can power the board on and off by just applying power. Ensure that your
+PDU provider or other power control solution is configured and you know which
+port it's connected to. Power switching is managed by setting "modes" for the
+relevant device in the ``devices`` section.  The modes can be arbitraily named,
+however the UI provides commands for enabling and disabling power and thus
+expects modes named ``on`` and ``off``. Add these to a ``modes`` section under
+the board node::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          - name: on
+            depends: off
+            sequence:
+              - match: &pdu-genio-700-1
+                  boardswarm.name: pdu.<pdu>.port-<index>
+                parameters:
+                  mode: on
+          - name: off
+            sequence:
+              - match: *pdu-genio-700-1
+                parameters:
+                  mode: off
+                stabilisation: 2s
+
+Restart boardswarm for the configuration changes to take effect. You should now
+be able to switch the board on and off with boardswarm from the command line::
+
+    $ boardswarm device genio-700-1 mode off
+    $ boardswarm device genio-700-1 mode on
+
+If the board already has something installed to boot and you have setup the
+serial as detailed above, you should also be able to
+:ref:`access the serial console <guides/basic-functionality:terminal style access to the board>`.
+
+
+Setting up GPIO
+---------------
+
+The FTDI USB serial chip used to provide access to the console on the Genio 700
+EVK also provides a number of GPIO pins that the board uses to enable USB
+control of the buttons found on the board. The details of how these GPIO pins
+are used is
+`documented in the MediaTek guide <https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/hw/g700-evk.html#ftdi-board-control>`_.
+The GPIO lines are exposed in Linux along with any other supported GPIO
+controller.
+
+.. note::
+  .. collapse:: Ensure the server is configured to allow boardswarm to access GPIOs
+
+    .. include:: ../guides/sections/gpio_udev.rst
+
+
+To enable them in Boardswarm we need to add a gpio node in the providers
+section of the config. The same match used for the console should be used in
+this section too::
+
+    providers:
+      - name: "genio-700-1 ftdi"
+        provider: gpio
+        parameters:
+          match: &genio-700-1-dongle
+            udev.ID_USB_SERIAL: "FTDI_FT232R_UB_UART_<serial>"
+          lines:
+            - line_number: 0
+              name: "genio-700-1-power"
+            - line_number: 1
+              name: "genio-700-1-reset"
+            - line_number: 2
+              name: "genio-700-1-download"
+
+Note that this section is also used to select the specific GPIO pins that will
+be controlled by Boardswarm and the names that can be used to identify them.
+
+These GPIO can then be used to perform operations, typically as sequences
+performed on mode changes. For example, if it is not desired to have a USB
+cable connected to the ``Micro USB D/L`` port of the EVK (however it should be
+noted this will be necessary for some of the following more complex operations
+which can be performed with the board), pressing of the power button can be
+simulated via the relevant pin as part of the ``on`` mode::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          - name: on
+            depends: off
+            sequence:
+              # Apply power
+              - match: &pdu-genio-700-1
+                  boardswarm.name: pdu.<pdu>.port-<index>
+                parameters:
+                  mode: on
+              # Toggle power button on and off
+              - match: &gpio-genio-700-1-power
+                  boardswarm.name: "genio-700-1-power"
+                parameters:
+                  value: true
+                stabilisation: 500ms
+              - match: *gpio-genio-700-1-power
+                parameters:
+                  value: false
+
+
+Setting up mediatek-brom
+------------------------
+
+With the GPIO enabled we can cause the board to boot into download mode. To use
+this mode we need a USB cable connecting the ``Micro USB D/L`` port to the
+boardswarm server.
+
+To enter download mode we add another mode to the device node, which can be
+called instead of the "on" mode to put the board into download mode::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          ...
+          - name: download
+            depends: off
+            sequence:
+              # Hold down "download" button
+              - match: &gpio-genio-700-1-download
+                  boardswarm.name: "genio-700-1-download"
+                parameters:
+                  value: true
+                stabilisation: 100ms
+              # Power on the board and stabilise
+              - match: *gpio-genio-700-1-power
+                parameters:
+                  mode: on
+                stabilisation: 2s
+              # Stop holding down the "download" button
+              - match: *gpio-genio-700-1-download
+                parameters:
+                  value: false
+
+Add a ``mediatek-brom`` node to the providers section to enable support for the
+MediaTek protocol used in this mode::
+
+    providers:
+      - name: mediatek-brom
+        provider: mediatek-brom
+
+Restart boardswarm to update the configuration.
+
+Ensure that Boardswarm has sufficient permissions to access the interface
+that's created in this mode by setting up a udev rule for it::
+
+    # MediaTek BROM
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="0003", GROUP="boardswarm"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    # udevadm control --reload && udevadm trigger
+
+Use the monitor to watch for volumes and print out details when a volume is seen::
+
+   $ boardswarm-cli monitor volumes -v
+
+From another terminal, switch the board into download mode::
+
+   $ boardswarm-cli device genio-700-1 mode download
+
+The ``mediatek-brom`` will detect the new connection on the ``Micro USB D/L``
+port and print out it's properties. Use this to create a volume under the board
+node. The serial provided by this interface is not unique, so here we will need
+to add a match using the ``ID_PATH`` property::
+
+    devices:
+      - name: genio-700-1
+        consoles:
+          ...
+        modes:
+          ...
+        volumes:
+          - name: genio-700-1-brom
+            match:
+              udev.ID_PATH: "<id_path>"
+
+Restart boardswarm to update the configuration.
+
+Setting up fastboot
+-------------------
+
+Genio devices can use the ``mediatek-brom`` mode to upload a
+`littlekernel <https://github.com/littlekernel>`_ based binary to bootstrap
+into a fastboot mode. To be able to use fastboot we need to enable and
+configure the boardswarm fastboot provider::
+
+    providers:
+      ...
+      - name: genio-fastboot
+        provider: fastboot
+        parameters:
+          match:
+            udev.ID_VENDOR_ID: 0e8d
+            udev.ID_MODEL_ID: 201c
+          targets:
+            - mmc0
+            - mmc0boot0
+            - mmc0boot1
+            - root
+
+Restart boardswarm to update the configuration.
+
+We also need to add some udev rules to allow the boardswarm server to have
+access to the required device files::
+
+    # MediaTek Fastboot
+    ACTION=="add", SUBSYSTEM=="usb", ENV{ID_USB_INTERFACES}==":ff4203:", GROUP="boardswarm"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    # udevadm control --reload && udevadm trigger
+
+With this and the ``mediatek-brom`` configured we can now use that to upload
+the littlekernel binary used to bootstrap into fastboot (this will typically be
+provided along side OS images to aid with flashing devices)::
+
+    $ boardswarm-cli device genio-700-1 mode off
+    $ boardswarm-cli device genio-700-1 mode download
+    $ boardswarm-cli device genio-700-1 write --commit genio-700-1-brom brom lk.bin
+
+The monitor launched above will show a ``mediatek-brom`` volume being created
+when powering on the board in download mode, which will be removed and replaced
+with a volume with the ``"boardswarm.provider" => "fastboot"`` property once
+bootstrapped into fastboot. As with ``mediatek-brom``, the serial number here
+is not unique, so we will create a volume node for the device using the
+``ID_PATH`` property listed for this volume::
+
+    volumes:
+      ...
+      - name: genio-700-1-fastboot
+        match:
+          udev.ID_PATH: "<id_path>"
+
+Restart boardswarm to update the configuration.
+
+
+Reflashing board
+----------------
+
+With Fastboot setup, we can reflash the board with the following commands::
+
+    $ boardswarm-cli device genio-700-1 write --commit genio-700-1-fastboot mmc0boot0 fip.img
+    $ boardswarm-cli device genio-700-1 write-aimg --commit genio-700-1-fastboot mmc0 <image>
+
+Reset the board to boot to the newly installed image. This can be achieved by
+power cycling the board::
+
+    $ boardswarm-cli device genio-700-1 mode off
+    $ boardswarm-cli device genio-700-1 mode on
+

--- a/website/conf.py
+++ b/website/conf.py
@@ -22,6 +22,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # Add the extension
 extensions = [
     "sphinx.ext.autosectionlabel",
+    "sphinx_toolbox.collapse",
     "sphinx.ext.intersphinx",
 ]
 

--- a/website/guides/sections/gpio_udev.rst
+++ b/website/guides/sections/gpio_udev.rst
@@ -1,0 +1,13 @@
+Ensure that Boardswarm has sufficient permissions to access GPIOs by setting up
+udev rules for it. This can be achieved by adding the following udev rule to
+the host running the boardswarm server. For example, by adding the file
+``/etc/udev/rules.d/99-boardswarm.rules`` with the following contents::
+
+    # Give boardswarm access to GPIO devices:
+    ACTION=="add", SUBSYSTEM=="gpio", NAME="gpiochip%n", GROUP="boardswarm"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    # udevadm control --reload && udevadm trigger
+
+

--- a/website/guides/sections/serial_identification.rst
+++ b/website/guides/sections/serial_identification.rst
@@ -1,0 +1,19 @@
+Run the following command to monitor new consoles added to the boardswarm
+server::
+
+   $ boardswarm-cli monitor consoles -v
+
+Boardswarm will detect the new addition of new USB serial device and print out
+the devices ID, name and a list of properties that can be used to identify the
+new serial console in the boardswarm server config file.
+
+If the device uses a legitimate FDTI chip to provide the USB serial, the serial
+device has a unique serial number. As a result the ``udev.ID_SERIAL`` entry is
+considered the best option, as this uniquely identifies the device, even if the
+device is moved to a different USB port (unlike using ``udev.ID_PATH`` which
+specifies the device plugged into a specific USB port). However if a unique
+serial number is not present then the path is generally the next best option.
+
+Once a suitable property has been identified done, we can kill the boardswarm
+monitor with ``ctrl-c``.
+

--- a/website/guides/sections/serial_udev.rst
+++ b/website/guides/sections/serial_udev.rst
@@ -1,0 +1,11 @@
+Ensure that Boardswarm has sufficient permissions to access USB serial devices
+that are attached to the system by adding the following udev rule to the host
+running the boardswarm server. (This can be achieve by adding the file
+``/etc/udev/rules.d/99-boardswarm.rules`` with the following contents::
+
+    # USB Serial devices
+    ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", GROUP="boardswarm"
+
+Ensure that the udev rule is in effect by rebooting or running::
+
+    # udevadm control --reload && udevadm trigger

--- a/website/guides/setup-server.rst
+++ b/website/guides/setup-server.rst
@@ -1,5 +1,26 @@
-==============================
-Setting up a Boardswarm server
-==============================
+==================================
+Setting up a server for boardswarm
+==================================
 
 Installing and configuring a Boardswarm server is currently documented in the `boardswarm server documentation <https://github.com/boardswarm/boardswarm/blob/main/boardswarm/README.md>`_.
+
+
+Serial
+======
+
+Allowing Boardswarm to access serial
+------------------------------------
+
+.. include:: sections/serial_udev.rst
+
+
+Serial identification
+---------------------
+
+.. include:: sections/serial_identification.rst
+
+
+Allowing Boardswarm to access GPIOs
+===================================
+
+.. include:: sections/gpio_udev.rst

--- a/website/index.rst
+++ b/website/index.rst
@@ -35,3 +35,9 @@ Full source code can be found in our github repository:
    guides/setup-server.rst
    guides/setup-client.rst
    guides/basic-functionality.rst
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Worked board examples
+
+   boards/mediatek.rst


### PR DESCRIPTION
This page currently covers the genio 700 EVK, but adding a more general page so that it can be expanded easier in the future for more similar boards.

Some of the very generic sections have been split out so that they can be included into this page and other pages in the future. I feel that having all the details on one page aids with following a guide, especially when new to something, rather than needing to jump all over the place to read sections on differnet pages.