### PR TITLE
docs: Document creation of boardswarm user & group

### DIFF
--- a/boardswarm/README.md
+++ b/boardswarm/README.md
@@ -119,6 +119,24 @@ As a starting point, the [example udev rules](share/99-boardswarm.rules) can be
 used to grant device permissions to boardswarm. It is recommended that these
 rules be used alongside the [example systemd service](share/boardswarm.service).
 
+If boardswarm connects to local physical devices on this machine using with the
+example udev rules, it is recommended to create a dedicated `boardswarm` user &
+group with:
+
+```
+$ sudo groupadd --system boardswarm
+
+$ sudo useradd --system --gid boardswarm \
+    --home-dir /nonexistent \
+    --shell /usr/sbin/nologin \
+    --comment "boardswarm service user" \
+    boardswarm
+```
+
+If boardswarm does not access local physical devices on this machine, or you use
+different device permission rules, you do not need to create a dedicated
+`boardswarm` user & group.
+
 ### Serial provider
 
 The serial provider creates consoles from local serial ports. No provider specific


### PR DESCRIPTION
Add instructions to create a dedicated system user and group for boardswarm when the service needs to access devices on the local machine.