### PR TITLE
udev: skip device Devantech USB Devices

### DIFF
--- a/boardswarm/share/99-boardswarm.rules
+++ b/boardswarm/share/99-boardswarm.rules
@@ -1,6 +1,14 @@
+# Skip Devantech USB devices as these are usually consumed by pdudaemon.
+# The Devantech USB product range uses the Microchip VID & a sub-licenced PID
+# specific to all Devantech products.
+# Warning: This catch-all rule will match more than the USB relay range.
+ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="ffee", GOTO="boardswarm_end"
+
 # USB Serial devices
 ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", GROUP="boardswarm"
 
 # TI DFU devices
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6162", GROUP="boardswarm"
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="6165", GROUP="boardswarm"
+
+LABEL="boardswarm_end"


### PR DESCRIPTION
Since the Devantech USB devices are not consumed by boardswarm, instead it is usually used by a pdudaemon instance, add an exception to udev rules to ignore the devices.

See the sister PR for pdudaemon at: https://github.com/pdudaemon/pdudaemon/pull/218/