### PR TITLE
Add uhubctl actuator provider

### DIFF
--- a/boardswarm/Dockerfile
+++ b/boardswarm/Dockerfile
@@ -33,6 +33,7 @@ LABEL org.opencontainers.image.source="https://github.com/boardswarm/boardswarm"
 RUN apt update && \
     apt install --yes \
       ca-certificates \
+      uhubctl \
       libudev1 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/boardswarm/share/server.conf
+++ b/boardswarm/share/server.conf
@@ -53,6 +53,14 @@ providers:
   # over serial at the moment
   - name: mediatek-brom
     provider: mediatek-brom
+  # A uhubctl provider to enable/disable power to USB hub ports.
+  - name: uhubctl
+    provider: uhubctl
+    parameters:
+      location: 1-2.4.4
+      ports:
+        - name: dut-power
+          port: 3
   # A fastboot provider for fastboot devices exposed over USB. As fastboot
   # partitions aren't necessarily discoverable this can be configured to match
   # certain devices and set a preconfigured set of targets

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -42,6 +42,7 @@ mod registry;
 mod rockusb;
 mod serial;
 mod udev;
+mod uhubctl;
 mod utils;
 
 #[derive(Error, Debug)]
@@ -1196,6 +1197,12 @@ async fn main() -> anyhow::Result<()> {
                 p.name,
                 p.parameters
                     .context("Missing pdudaemon provider parameters")?,
+                server.clone(),
+            ),
+            uhubctl::PROVIDER => uhubctl::start_provider(
+                p.name,
+                p.parameters
+                    .context("Missing uhubctl provider parameters")?,
                 server.clone(),
             ),
             boardswarm_provider::PROVIDER => boardswarm_provider::start_provider(

--- a/boardswarm/src/uhubctl.rs
+++ b/boardswarm/src/uhubctl.rs
@@ -1,0 +1,108 @@
+use serde::Deserialize;
+use tracing::{instrument, warn};
+
+use crate::{
+    ActuatorError, Server,
+    registry::{self, Properties},
+};
+
+pub const PROVIDER: &str = "uhubctl";
+
+#[derive(Deserialize, Debug)]
+struct PortConfig {
+    name: String,
+    port: u32,
+}
+
+#[derive(Deserialize, Debug)]
+struct UhubctlParameters {
+    location: String,
+    path: Option<String>,
+    ports: Vec<PortConfig>,
+}
+
+#[instrument(skip(parameters, server))]
+pub fn start_provider(name: String, parameters: serde_yaml::Value, server: Server) {
+    let parameters: UhubctlParameters = serde_yaml::from_value(parameters).unwrap();
+    let provider_properties = &[
+        (registry::PROVIDER_NAME, name.as_str()),
+        (registry::PROVIDER, PROVIDER),
+    ];
+
+    for port_config in &parameters.ports {
+        let actuator_name = format!("{}.{}.port-{}", name, parameters.location, port_config.port);
+        let mut properties = Properties::new(actuator_name);
+        properties.extend(provider_properties);
+        properties.insert("uhubctl.location", parameters.location.clone());
+        properties.insert("uhubctl.name", port_config.name.clone());
+        properties.insert("uhubctl.port", port_config.port.to_string());
+
+        let actuator = UhubctlActuator {
+            path: parameters
+                .path
+                .clone()
+                .unwrap_or_else(|| "/usr/sbin/uhubctl".to_string()),
+            location: parameters.location.clone(),
+            port: port_config.port,
+        };
+        server.register_actuator(properties, actuator);
+    }
+}
+
+#[derive(Debug)]
+struct UhubctlActuator {
+    path: String,
+    location: String,
+    port: u32,
+}
+
+#[async_trait::async_trait]
+impl crate::Actuator for UhubctlActuator {
+    async fn set_mode(
+        &self,
+        parameters: Box<dyn erased_serde::Deserializer<'static> + Send>,
+    ) -> Result<(), ActuatorError> {
+        #[derive(Deserialize)]
+        struct ModeParameters {
+            mode: String,
+        }
+        let parameters = ModeParameters::deserialize(parameters).unwrap();
+        let action = match parameters.mode.as_str() {
+            "on" => "on",
+            "off" => "off",
+            _ => {
+                warn!(
+                    "Unsupported mode '{}' for uhubctl actuator at {}:{}",
+                    parameters.mode, self.location, self.port
+                );
+                return Err(ActuatorError());
+            }
+        };
+
+        let status = tokio::process::Command::new(&self.path)
+            .args([
+                "-l",
+                &self.location,
+                "-p",
+                &self.port.to_string(),
+                "-a",
+                action,
+            ])
+            .status()
+            .await
+            .map_err(|e| {
+                warn!("Failed to run uhubctl: {e}");
+                ActuatorError()
+            })?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            warn!(
+                "uhubctl exited with status {} for {}:{}",
+                status, self.location, self.port
+            );
+            Err(ActuatorError())
+        }
+    }
+}


### PR DESCRIPTION
Add a new provider to integrate uhubctl and control USB hub port power.
Each configured port is registered as an actuator supporting "on" and
"off" modes, which invokes `uhubctl -l <location> -p <port> -a <on|off>`.

The provider is configured with a hub location, an optional path to the
uhubctl binary and a list of ports with descriptive names.