### PR TITLE
boardswarm-cli: Add blocking console connection (formerly PR!279)

### DIFF
--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -473,6 +473,35 @@ struct DeviceConsoleArgs {
     /// Console to open instead of the default
     #[clap(short, long)]
     console: Option<String>,
+    /// Wait for the console to become available
+    #[clap(short, long)]
+    wait: bool,
+}
+
+impl DeviceConsoleArgs {
+    async fn open(
+        &self,
+        device: &boardswarm_client::device::Device,
+    ) -> anyhow::Result<boardswarm_client::device::DeviceConsole> {
+        let console = if let Some(c) = &self.console {
+            device
+                .console_by_name(c)
+                .ok_or_else(|| anyhow::anyhow!("Console not found"))?
+        } else {
+            device
+                .console()
+                .ok_or_else(|| anyhow::anyhow!("Console not found"))?
+        };
+        if !console.available() {
+            if self.wait {
+                eprintln!("Waiting for console..");
+                console.wait_available().await;
+            } else {
+                bail!("console not available");
+            }
+        }
+        Ok(console)
+    }
 }
 
 #[derive(Debug, Args)]
@@ -1366,15 +1395,7 @@ async fn main() -> anyhow::Result<()> {
                     device.change_mode("on").await?;
                 }
                 DeviceCommand::Connect(d) => {
-                    let mut console = if let Some(c) = &d.console {
-                        device
-                            .console_by_name(c)
-                            .ok_or_else(|| anyhow::anyhow!("Console not found"))?
-                    } else {
-                        device
-                            .console()
-                            .ok_or_else(|| anyhow::anyhow!("Console not found"))?
-                    };
+                    let mut console = d.open(&device).await?;
                     let out = copy_output_to_stdout(console.stream_output().await?);
                     let in_ = console.stream_input(input_stream());
                     futures::select! {
@@ -1383,15 +1404,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
                 DeviceCommand::Tail(d) => {
-                    let mut console = if let Some(c) = &d.console {
-                        device
-                            .console_by_name(c)
-                            .ok_or_else(|| anyhow::anyhow!("Console not found"))?
-                    } else {
-                        device
-                            .console()
-                            .ok_or_else(|| anyhow::anyhow!("Console not found"))?
-                    };
+                    let mut console = d.open(&device).await?;
                     let output = console.stream_output().await?;
                     copy_output_to_stdout(output).await?;
                 }
@@ -1448,7 +1461,8 @@ async fn main() -> anyhow::Result<()> {
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Device not found"))?;
 
-            ui::run_ui(device, console.console, terminal_size, scrollback_lines).await
+            let console = console.open(&device).await?;
+            ui::run_ui(device, console, terminal_size, scrollback_lines).await
         }
     }
 }

--- a/boardswarm-cli/src/ui.rs
+++ b/boardswarm-cli/src/ui.rs
@@ -240,7 +240,7 @@ where
 
 pub async fn run_ui(
     device: boardswarm_client::device::Device,
-    console: Option<String>,
+    mut console: boardswarm_client::device::DeviceConsole,
     terminal_size_setting: TerminalSizeSetting,
     scrollback_lines: usize,
 ) -> anyhow::Result<()> {
@@ -265,11 +265,6 @@ pub async fn run_ui(
     .unwrap();
 
     let mut terminal = Terminal::new(terminal_size_setting, scrollback_lines, terminal).await;
-    let mut console = match console {
-        Some(console) => device.console_by_name(&console),
-        None => device.console(),
-    }
-    .ok_or_else(|| anyhow::anyhow!("Console not available"))?;
 
     let mut output_console = console.clone();
     let output = output_console.stream_output().await?;

--- a/boardswarm-client/src/device.rs
+++ b/boardswarm-client/src/device.rs
@@ -155,6 +155,14 @@ impl DeviceConsole {
         self.get_id().is_some()
     }
 
+    /// Wait for the console to become available
+    pub async fn wait_available(&self) {
+        let mut watch = self.device.watch();
+        while !self.available() {
+            watch.changed().await;
+        }
+    }
+
     pub async fn stream_input<I>(&mut self, input: I) -> Result<(), tonic::Status>
     where
         I: Stream<Item = Bytes> + Send + 'static,


### PR DESCRIPTION
Follow up of https://github.com/boardswarm/boardswarm/pull/279 (closed in favor of this PR)

```
    boardswarm-cli: Add blocking console connection
    
    This patch adds "--wait" flag to boardswarm-cli commands:
    
    - boardswarm-cli device <DEVICE> connect --wait
    - boardswarm-cli ui --wait <DEVICE>
    
    Its purpose is to block until the requested device's console becomes
    available.
    
    Behavior on console disconnection (after initial connection) remains
    unchanged: there will be no auto-reconnect attempts.
```