### PR TITLE
Bump rand for GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2942,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
Fix https://github.com/advisories/GHSA-cq8v-f236-94qc for the rand 0.9 crate. Sadly jsonwebtoken still depends on rand 0.8 for which no update is available.