### PR TITLE
boardswarm-cli: add shell completion for ui <device>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "boardswarm-protocol",
  "bytes",
  "clap",
+ "clap_complete",
  "dirs",
  "futures",
  "http",
@@ -471,7 +472,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -526,6 +527,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1818,6 +1831,15 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3671,6 +3693,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"

--- a/boardswarm-cli/Cargo.toml
+++ b/boardswarm-cli/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 anyhow = "1.0.68"
 bytes = "1.10.1"
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 futures = "0.3.31"
 vt100 = "0.16"
 nix = { version = "0.31.2", features = ["term"] }

--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     convert::Infallible,
+    ffi::OsStr,
     io::SeekFrom,
     path::{Path, PathBuf},
     time::Duration,
@@ -17,7 +18,11 @@ use boardswarm_client::{
 };
 use boardswarm_protocol::ItemType;
 use bytes::{Bytes, BytesMut};
-use clap::{Args, Parser, Subcommand, ValueEnum, builder::PossibleValue};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCompleter, CompletionCandidate},
+};
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt, pin_mut};
 use http::Uri;
 use indicatif::ProgressBar;
@@ -468,6 +473,87 @@ fn parse_device(device: &str) -> Result<DeviceArg, Infallible> {
     }
 }
 
+/// Peek at a `-x <value>`, `--long <value>` or `--long=<value>` global option
+/// straight from argv.
+fn completion_global_arg(short: &str, long: &str) -> Option<String> {
+    let mut args = std::env::args();
+    while let Some(arg) = args.next() {
+        if arg == short || arg == long {
+            return args.next();
+        }
+        if let Some(value) = arg.strip_prefix(&format!("{long}=")) {
+            return Some(value.to_owned());
+        }
+    }
+    None
+}
+
+/// Resolve the config path with `-c/--config`.
+fn completion_config_path() -> Option<PathBuf> {
+    if let Some(path) = completion_global_arg("-c", "--config") {
+        return Some(PathBuf::from(path));
+    }
+    let mut c = dirs::config_dir()?;
+    c.push("boardswarm");
+    c.push("config.yaml");
+    Some(c)
+}
+
+/// Query the server for devices and turn the list into completion candidates.
+/// Any failure (no config, unreachable server, auth required) fails quietly.
+async fn list_device_candidates() -> Vec<CompletionCandidate> {
+    let Some(config_path) = completion_config_path() else {
+        return Vec::new();
+    };
+    let Ok(config) = config::Config::from_file(&config_path).await else {
+        return Vec::new();
+    };
+    let server = match completion_global_arg("-i", "--instance") {
+        Some(name) => config.find_server(&name),
+        None => config.default_server(),
+    };
+    let Some(server) = server else {
+        return Vec::new();
+    };
+    // Deliberately no login provider: completion must never prompt or write to
+    // stdout. If the cached credentials are missing or stale, `list` simply
+    // fails and returns nothing.
+    let Ok(mut client) = server.to_boardswarm_builder().connect().await else {
+        return Vec::new();
+    };
+    let Ok(items) = client.list(ItemType::Device).await else {
+        return Vec::new();
+    };
+    items
+        .into_iter()
+        .map(|item| {
+            CompletionCandidate::new(item.name).help(Some(format!("id {}", item.id).into()))
+        })
+        .collect()
+}
+
+/// Dynamic completer for a device argument: lists devices from the server at
+/// tab-completion time. Runs outside the async runtime with a short timeout
+/// such that tab completion never hangs on an unreachable server.
+fn complete_device(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return Vec::new();
+    };
+    let mut candidates = rt.block_on(async {
+        tokio::time::timeout(Duration::from_secs(2), list_device_candidates())
+            .await
+            .unwrap_or_default()
+    });
+    // The ArgValueCompleter path doesn't prefix-filter for us, so keep only the
+    // candidates matching what the user has typed so far.
+    let prefix = current.to_string_lossy();
+    candidates.retain(|c| c.get_value().to_string_lossy().starts_with(prefix.as_ref()));
+    candidates
+}
+
 #[derive(Clone, Debug, Args)]
 struct DeviceConsoleArgs {
     /// Console to open instead of the default
@@ -737,7 +823,7 @@ enum Command {
     },
     /// Open the UI for a given device
     Ui {
-        #[arg(value_parser = parse_device)]
+        #[arg(value_parser = parse_device, add = ArgValueCompleter::new(complete_device))]
         /// The device to use
         device: DeviceArg,
         #[command(flatten)]
@@ -1021,12 +1107,25 @@ async fn print_device(
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     // Temporarily set the default rustls crypto provider to aws-lc-rs until
     // reqwest allows this by default via a feature
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
+    // Handle shell completion requests before starting the async runtime: when
+    // the completion env var is set this resolves candidates (including live
+    // device names, see `complete_device`) and exits. Running it outside the
+    // runtime lets `complete_device` spin up its own runtime to query the
+    // server.
+    CompleteEnv::with_factory(Opts::command).complete();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let opt = Opts::parse();
     if !matches!(opt.command, Command::Ui { .. }) {
         tracing_subscriber::fmt::init();


### PR DESCRIPTION
Wire up clap_complete's dynamic completion engine such that pressing TAB after `boardswarm-cli ui` completes device names from the server.

A custom ArgValueCompleter on the `ui` device argument connects to the boardswarm server and lists its devices. The device completion fails silently so to not disrupts the shell: device names are read from the server with a 2s timeout so we never hang when querying an unreachable server.

Only the `ui` subcommand is covered for now. Additional subcommands such as `device` and `rock` could also have similar TAB logic.

To enable this with a local build:

    source <(COMPLETE=bash ~/projects/git/boardswarm/target/debug/boardswarm-cli)
    alias boardswarm-cli=~/projects/git/boardswarm/target/debug/boardswarm-cli

Then `boardswarm-cli ui <TAB>`. To install it permanently when the binary is installed in PATH:

    echo 'source <(COMPLETE=bash boardswarm-cli)' >> ~/.bashrc