### PR TITLE
Add --version argument to boardswarm and boardswarm-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v4
       - uses: actions/checkout@v6
+      - name: Compute version
+        id: version
+        run: |
+          crate_version=$(grep -m1 '^version' "${{ matrix.binary }}/Cargo.toml" | cut -d'"' -f2)
+          echo "value=${crate_version} ($(git rev-parse --short HEAD))" >> "$GITHUB_OUTPUT"
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -123,6 +128,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.binary }}/Dockerfile
+          build-args: |
+            BOARDSWARM_VERSION=${{ steps.version.outputs.value }}
 
   allgreen:
     if: always()

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -41,7 +41,11 @@ jobs:
             ${{matrix.architecture.packages}} ""
       - run: rustup target add ${{matrix.architecture.rust}}
       - env: ${{matrix.architecture.env}}
-        run: cargo build --release --target ${{matrix.architecture.rust}}
+        shell: bash
+        run: |
+          crate_version=$(grep -m1 '^version' boardswarm/Cargo.toml | cut -d'"' -f2)
+          export BOARDSWARM_VERSION="${crate_version} (${GITHUB_SHA:0:7})"
+          cargo build --release --target ${{matrix.architecture.rust}}
       - name: Prepare tarball
         run: |
           mkdir -v ${OUTDIR}

--- a/boardswarm-cli/Dockerfile
+++ b/boardswarm-cli/Dockerfile
@@ -1,5 +1,6 @@
 ## stage 1: builder
 FROM rust:slim-trixie AS builder
+ARG BOARDSWARM_VERSION
 ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/boardswarm-cli/build.rs
+++ b/boardswarm-cli/build.rs
@@ -1,0 +1,44 @@
+use std::process::Command;
+
+/// Determine the version string to embed into the binary.
+/// The version is exposed via the CLI argument `--version`.
+///
+/// Version resolution order:
+/// 1. `BOARDSWARM_VERSION` environment variable
+/// 2. `git describe`
+/// 3. The crate version from `Cargo.toml`
+fn main() {
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+
+    let version = std::env::var("BOARDSWARM_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| git_describe().map(|git| format!("{pkg_version} ({git})")))
+        .unwrap_or(pkg_version);
+
+    println!("cargo:rustc-env=BOARDSWARM_VERSION={version}");
+
+    // Re run when the injected version or the git state changes.
+    println!("cargo:rerun-if-env-changed=BOARDSWARM_VERSION");
+    for path in ["../.git/HEAD", "../.git/index"] {
+        if std::path::Path::new(path).exists() {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+fn git_describe() -> Option<String> {
+    // Ignore git tags (tags are created per crate, e.g. `boardswarm-v0.0.1`).
+    let output = Command::new("git")
+        .args(["describe", "--always", "--dirty", "--exclude=*"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let version = String::from_utf8(output.stdout).ok()?;
+    let version = version.trim();
+    (!version.is_empty()).then(|| version.to_string())
+}

--- a/boardswarm-cli/src/main.rs
+++ b/boardswarm-cli/src/main.rs
@@ -914,6 +914,7 @@ async fn run_auth_modify(
 }
 
 #[derive(clap::Parser)]
+#[command(version = env!("BOARDSWARM_VERSION"))]
 struct Opts {
     #[clap(short, long)]
     config: Option<PathBuf>,

--- a/boardswarm/Dockerfile
+++ b/boardswarm/Dockerfile
@@ -1,5 +1,6 @@
 ## stage 1: builder
 FROM rust:slim-trixie AS builder
+ARG BOARDSWARM_VERSION
 ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/boardswarm/build.rs
+++ b/boardswarm/build.rs
@@ -1,0 +1,44 @@
+use std::process::Command;
+
+/// Determine the version string to embed into the binary.
+/// The version is exposed via the CLI argument `--version`.
+///
+/// Version resolution order:
+/// 1. `BOARDSWARM_VERSION` environment variable
+/// 2. `git describe`
+/// 3. The crate version from `Cargo.toml`
+fn main() {
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+
+    let version = std::env::var("BOARDSWARM_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| git_describe().map(|git| format!("{pkg_version} ({git})")))
+        .unwrap_or(pkg_version);
+
+    println!("cargo:rustc-env=BOARDSWARM_VERSION={version}");
+
+    // Re run when the injected version or the git state changes.
+    println!("cargo:rerun-if-env-changed=BOARDSWARM_VERSION");
+    for path in ["../.git/HEAD", "../.git/index"] {
+        if std::path::Path::new(path).exists() {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+fn git_describe() -> Option<String> {
+    // Ignore git tags (tags are created per crate, e.g. `boardswarm-v0.0.1`).
+    let output = Command::new("git")
+        .args(["describe", "--always", "--dirty", "--exclude=*"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let version = String::from_utf8(output.stdout).ok()?;
+    let version = version.trim();
+    (!version.is_empty()).then(|| version.to_string())
+}

--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -1069,6 +1069,7 @@ async fn setup_auth_layer(
 }
 
 #[derive(Debug, clap::Parser)]
+#[command(version = env!("BOARDSWARM_VERSION"))]
 struct Opts {
     #[clap(short, long)]
     #[arg(value_parser = parse_listen_address)]


### PR DESCRIPTION
Add an argument to the boardswarm CLI binaries to report the version.

The version is determined at build time in this order:
1. BOARDSWARM_VERSION environment variable
2. `git describe`; which produces "<crate version> (<commit>[-dirty])"
3. the crate version from Cargo.toml

Also inject the version when building in GitHub actions and when building the boardswarm containers.