### PR TITLE
Dockerfile: remove unused build argument BINARY

### DIFF
--- a/boardswarm-cli/Dockerfile
+++ b/boardswarm-cli/Dockerfile
@@ -1,6 +1,5 @@
 ## stage 1: builder
 FROM rust:slim-trixie AS builder
-ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -19,7 +18,6 @@ RUN cargo build \
 
 ## stage 2: runner
 FROM debian:trixie-slim
-ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 ENV RUST_LOG=info
 

--- a/boardswarm/Dockerfile
+++ b/boardswarm/Dockerfile
@@ -1,6 +1,5 @@
 ## stage 1: builder
 FROM rust:slim-trixie AS builder
-ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -20,7 +19,6 @@ RUN cargo build \
 
 ## stage 2: runner
 FROM debian:trixie-slim
-ARG BINARY
 ARG DEBIAN_FRONTEND=noninteractive
 ENV RUST_LOG=info
 


### PR DESCRIPTION
The BINARY build argument was declared in both the boardswarm and boardswarm-cli Dockerfiles but never referenced. Drop it.